### PR TITLE
refactor: Move common Compose dependencies to convention plugins

### DIFF
--- a/buildSrc/src/main/kotlin/compose-multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/compose-multiplatform-convention.gradle.kts
@@ -23,18 +23,6 @@ kotlin {
     }
 
     jvm()
-
-    sourceSets {
-        commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-        }
-        commonTest.dependencies {
-            implementation(libs.findLibrary("kotlin-test").get())
-        }
-    }
 }
 
 android {

--- a/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-multiplatform-convention.gradle.kts
@@ -10,7 +10,7 @@ val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 kotlin {
     androidTarget()
-    
+
     listOf(
         iosArm64(),
         iosSimulatorArm64()
@@ -20,17 +20,8 @@ kotlin {
             isStatic = true
         }
     }
-    
+
     jvm()
-    
-    sourceSets {
-        commonMain.dependencies {
-            // Add common dependencies here
-        }
-        commonTest.dependencies {
-            implementation(libs.findLibrary("kotlin-test").get())
-        }
-    }
 }
 
 android {

--- a/feature/reading_plan/build.gradle.kts
+++ b/feature/reading_plan/build.gradle.kts
@@ -2,6 +2,11 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeMultiplatformConvention)
 }
+
+android {
+    namespace = "com.quare.bibleplanner.feature.readingplan"
+}
+
 kotlin {
     sourceSets {
         commonMain.dependencies {
@@ -9,6 +14,10 @@ kotlin {
             implementation(projects.core.model)
 
             // Compose
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material3)
+            implementation(compose.ui)
             implementation(compose.components.resources)
 
             // Navigation
@@ -21,7 +30,4 @@ kotlin {
             implementation(libs.koinComposeViewModel)
         }
     }
-}
-android {
-    namespace = "com.quare.bibleplanner.feature.readingplan"
 }

--- a/ui/theme/build.gradle.kts
+++ b/ui/theme/build.gradle.kts
@@ -3,6 +3,18 @@ plugins {
     alias(libs.plugins.composeMultiplatformConvention)
 }
 
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            // Compose
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material3)
+            implementation(compose.ui)
+        }
+    }
+}
+
 android {
     namespace = "com.quare.bibleplanner.ui.theme"
 }


### PR DESCRIPTION
This commit centralizes common Compose dependencies by moving them from individual feature modules (`feature:reading_plan`, `ui:theme`) into the `compose-multiplatform-convention.gradle.kts` convention plugin.

This change simplifies module-level `build.gradle.kts` files and ensures consistent dependency management across all modules that use Compose Multiplatform. The empty `sourceSets` block was also removed from the `kotlin-multiplatform-convention.gradle.kts` for better clarity.