### PR TITLE
refactor: Change reading progress calculation to be verse-based

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.androidApplication) apply false
@@ -34,6 +35,15 @@ subprojects {
         }
     }
 
+    // Configure Kotlin compiler to use -Xexpect-actual-classes flag
+    // This suppresses warnings about expect/actual classes being in Beta
+    // This applies to all Kotlin compilation, including when ktlint uses the compiler
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
+    }
+
     // Ensure KSP code generation runs before ktlint for projects with KSP
     // This is important for Room's DatabaseConstructor and other generated code
     afterEvaluate {
@@ -46,14 +56,14 @@ subprojects {
                 "kspKotlinAndroid",
                 "kspKotlinJvm",
             )
-            
+
             // Also try iOS targets, but they may fail in CI without native toolchains
             val secondaryKspTaskNames = listOf(
                 "kspKotlinMetadata",
                 "kspKotlinIosArm64",
                 "kspKotlinIosSimulatorArm64",
             )
-            
+
             // Add dependencies for primary targets (required)
             primaryKspTaskNames.forEach { taskName ->
                 val kspTask = tasks.findByName(taskName)
@@ -61,7 +71,7 @@ subprojects {
                     ktlintCheckTask.dependsOn(kspTask)
                 }
             }
-            
+
             // Add dependencies for secondary targets (optional - may fail in CI)
             secondaryKspTaskNames.forEach { taskName ->
                 val kspTask = tasks.findByName(taskName)

--- a/core/model/src/commonMain/kotlin/com/quare/bibleplanner/core/model/plan/DayModel.kt
+++ b/core/model/src/commonMain/kotlin/com/quare/bibleplanner/core/model/plan/DayModel.kt
@@ -4,4 +4,6 @@ data class DayModel(
     val number: Int,
     val passages: List<PassagePlanModel>,
     val isRead: Boolean,
+    val totalVerses: Int,
+    val readVerses: Int,
 )

--- a/core/plan/src/commonMain/kotlin/com/quare/bibleplanner/core/plan/data/mapper/WeekPlanDtoToModelMapper.kt
+++ b/core/plan/src/commonMain/kotlin/com/quare/bibleplanner/core/plan/data/mapper/WeekPlanDtoToModelMapper.kt
@@ -26,6 +26,8 @@ class WeekPlanDtoToModelMapper(
             mapBook(bookDto)
         },
         isRead = false,
+        readVerses = 0,
+        totalVerses = 0,
     )
 
     private fun mapBook(bookDto: BookPlanDto): PassagePlanModel? {

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/viewmodel/ReadingPlanViewModel.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/viewmodel/ReadingPlanViewModel.kt
@@ -75,13 +75,11 @@ internal class ReadingPlanViewModel(
                                 ReadingPlanType.CHRONOLOGICAL -> plansModel.chronologicalOrder
                                 ReadingPlanType.BOOKS -> plansModel.booksOrder
                             }
-                            val progress = calculateProgress(selectedWeeks)
                             val weekPresentationModels = createWeekPresentationModels(selectedWeeks)
 
                             currentUiState.copy(
                                 weekPlans = weekPresentationModels,
                                 selectedReadingPlan = event.type,
-                                progress = progress,
                             )
                         }
 
@@ -152,13 +150,15 @@ internal class ReadingPlanViewModel(
     private fun calculateProgress(weeks: List<WeekPlanModel>): Float {
         if (weeks.isEmpty()) return 0f
 
-        val totalDays = weeks.sumOf { it.days.size }
-        if (totalDays == 0) return 0f
+        val totalVerses = weeks.sumOf { week ->
+            week.days.sumOf { it.totalVerses }
+        }
+        if (totalVerses == 0) return 0f
 
-        val readDays = weeks.sumOf { week ->
-            week.days.count { it.isRead }
+        val readVerses = weeks.sumOf { week ->
+            week.days.sumOf { it.readVerses }
         }
 
-        return 100 * (readDays.toFloat() / totalDays.toFloat())
+        return 100 * (readVerses.toFloat() / totalVerses.toFloat())
     }
 }


### PR DESCRIPTION
This commit refactors the reading progress calculation to be based on the number of verses read rather than the number of days completed.

Key changes:
- The progress calculation in `ReadingPlanViewModel` now uses `readVerses` and `totalVerses` for a more granular progress tracking.
- `DayModel` is updated to include `totalVerses` and `readVerses` fields.
- `GetPlansByWeekUseCase` now calculates the total and read verses for each day, considering specific chapter and verse ranges in the reading plan.
- The root `build.gradle.kts` is updated to suppress warnings for `expect`/`actual` classes by adding the `-Xexpect-actual-classes` compiler flag.