### PR TITLE
refactor: Encapsulate chapter read status calculation in a use case

### DIFF
--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/di/DayModule.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/di/DayModule.kt
@@ -5,6 +5,7 @@ import com.quare.bibleplanner.feature.day.data.mapper.DayEntityToModelMapper
 import com.quare.bibleplanner.feature.day.data.repository.DayRepositoryImpl
 import com.quare.bibleplanner.feature.day.domain.EditDaySelectableDates
 import com.quare.bibleplanner.feature.day.domain.repository.DayRepository
+import com.quare.bibleplanner.feature.day.domain.usecase.CalculateAllChaptersReadStatusUseCase
 import com.quare.bibleplanner.feature.day.domain.usecase.CalculateChapterReadStatusUseCase
 import com.quare.bibleplanner.feature.day.domain.usecase.ConvertTimestampToDatePickerInitialDateUseCase
 import com.quare.bibleplanner.feature.day.domain.usecase.ConvertUtcDateToLocalDateUseCase
@@ -40,6 +41,7 @@ val dayModule = module {
     factoryOf(::UpdateChapterReadStatusUseCase)
     factoryOf(::UpdateDayReadTimestampUseCase)
     factoryOf(::CalculateChapterReadStatusUseCase)
+    factoryOf(::CalculateAllChaptersReadStatusUseCase)
     factoryOf(::ToggleChapterReadStatusUseCase)
     factoryOf(::ConvertUtcDateToLocalDateUseCase)
     factoryOf(::GetFinalTimestampAfterEditionUseCase)

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/domain/usecase/CalculateAllChaptersReadStatusUseCase.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/domain/usecase/CalculateAllChaptersReadStatusUseCase.kt
@@ -1,0 +1,64 @@
+package com.quare.bibleplanner.feature.day.domain.usecase
+
+import com.quare.bibleplanner.core.model.book.BookDataModel
+import com.quare.bibleplanner.core.model.plan.ChapterPlanModel
+import com.quare.bibleplanner.core.model.plan.PassagePlanModel
+
+class CalculateAllChaptersReadStatusUseCase {
+    /**
+     * Calculate the read status for each chapter in each passage.
+     * Returns a map where the key is (passageIndex, chapterIndex) and the value is whether the chapter is read.
+     */
+    operator fun invoke(
+        passages: List<PassagePlanModel>,
+        books: List<BookDataModel>,
+    ): Map<Pair<Int, Int>, Boolean> {
+        val statusMap = mutableMapOf<Pair<Int, Int>, Boolean>()
+
+        passages.forEachIndexed { passageIndex, passage ->
+            passage.chapters.forEachIndexed { chapterIndex, chapter ->
+                val isRead = isChapterRead(passage, chapter, books)
+                statusMap[passageIndex to chapterIndex] = isRead
+            }
+        }
+
+        return statusMap
+    }
+
+    /**
+     * Check if a specific chapter within a passage is read by checking the book data.
+     */
+    private fun isChapterRead(
+        passage: PassagePlanModel,
+        chapter: ChapterPlanModel,
+        books: List<BookDataModel>,
+    ): Boolean {
+        val book = books.find { it.id == passage.bookId } ?: return false
+        val bookChapter = book.chapters.find { it.number == chapter.number } ?: return false
+
+        val startVerse = chapter.startVerse
+        val endVerse = chapter.endVerse
+
+        return when {
+            // If verse range is specified, check those specific verses
+            startVerse != null && endVerse != null -> {
+                val requiredVerses = startVerse..endVerse
+                requiredVerses.all { verseNumber ->
+                    bookChapter.verses.find { it.number == verseNumber }?.isRead == true
+                }
+            }
+
+            // If only start verse is specified, check from that verse to end of chapter
+            startVerse != null -> {
+                bookChapter.verses
+                    .filter { it.number >= startVerse }
+                    .all { it.isRead }
+            }
+
+            // If no verse range specified, check if entire chapter is read
+            else -> {
+                bookChapter.isRead
+            }
+        }
+    }
+}

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/content/LoadedDayContent.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/content/LoadedDayContent.kt
@@ -27,7 +27,7 @@ internal fun LoadedDayContent(
     ) {
         passageList(
             passages = uiState.day.passages,
-            books = uiState.books,
+            chapterReadStatus = uiState.chapterReadStatus,
             onChapterToggle = { passageIndex, chapterIndex ->
                 onEvent(DayUiEvent.OnChapterToggle(passageIndex, chapterIndex))
             },

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/factory/DayUiStateFlowFactory.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/factory/DayUiStateFlowFactory.kt
@@ -2,6 +2,7 @@ package com.quare.bibleplanner.feature.day.presentation.factory
 
 import com.quare.bibleplanner.core.model.plan.ReadingPlanType
 import com.quare.bibleplanner.feature.day.domain.EditDaySelectableDates
+import com.quare.bibleplanner.feature.day.domain.usecase.CalculateAllChaptersReadStatusUseCase
 import com.quare.bibleplanner.feature.day.domain.usecase.ConvertTimestampToDatePickerInitialDateUseCase
 import com.quare.bibleplanner.feature.day.domain.usecase.GetBooksUseCase
 import com.quare.bibleplanner.feature.day.domain.usecase.GetDayDetailsUseCase
@@ -23,6 +24,7 @@ internal class DayUiStateFlowFactory(
     private val readDateFormatter: ReadDateFormatter,
     private val editDaySelectableDates: EditDaySelectableDates,
     private val convertTimestampToDatePickerInitialDate: ConvertTimestampToDatePickerInitialDateUseCase,
+    private val calculateAllChaptersReadStatus: CalculateAllChaptersReadStatusUseCase,
 ) {
     fun createUiState(
         weekNumber: Int,
@@ -76,6 +78,10 @@ internal class DayUiStateFlowFactory(
                 books = books,
                 datePickerUiState = datePickerUiState,
                 formattedReadDate = day.readTimestamp?.let(readDateFormatter::format),
+                chapterReadStatus = calculateAllChaptersReadStatus(
+                    passages = day.passages,
+                    books = books,
+                ),
             )
         } else {
             DayUiState.Loading

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/model/DayUiState.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/model/DayUiState.kt
@@ -12,5 +12,6 @@ internal sealed interface DayUiState {
         val books: List<BookDataModel>,
         val datePickerUiState: DatePickerUiState,
         val formattedReadDate: String?,
+        val chapterReadStatus: Map<Pair<Int, Int>, Boolean>,
     ) : DayUiState
 }


### PR DESCRIPTION
This commit introduces the `CalculateAllChaptersReadStatusUseCase` to encapsulate the logic for determining the read status of all chapters for a given day.

Key changes include:
*   Creating the new `CalculateAllChaptersReadStatusUseCase` which centralizes the logic to check if a chapter or a range of verses is marked as read.
*   Moving the read status calculation logic out of the `PassageList` composable and into this dedicated use case.
*   Updating `DayUiStateFlowFactory` to use the new use case to pre-calculate the read status for all chapters and include it in the `DayUiState`.
*   Simplifying the `PassageList` composable, which now receives the calculated read status map directly from the UI state.
*   Registering the new use case in the dependency injection graph.