### PR TITLE
Feature: Animation in week progress + Refactor ReadingPlan UI

### DIFF
--- a/feature/reading_plan/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/reading_plan/src/commonMain/composeResources/values-es/strings.xml
@@ -5,7 +5,7 @@
     <string name="progress_label">Progreso: %1$d %</string>
     <string name="loading">Cargando...</string>
     <string name="week_number">Semana %1$d</string>
-    <string name="week_progress_description">%1$d/%2$d completo</string>
+    <string name="week_progress_complete">completo</string>
     <string name="day_number">Día %1$d</string>
     <string name="more_options">Más opciones</string>
     <string name="theme_option">Tema</string>

--- a/feature/reading_plan/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/feature/reading_plan/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -5,7 +5,7 @@
     <string name="progress_label">Progresso: %1$d %</string>
     <string name="loading">Carregando...</string>
     <string name="week_number">Semana %1$d</string>
-    <string name="week_progress_description">%1$d/%2$d completo</string>
+    <string name="week_progress_complete">completo</string>
     <string name="day_number">Dia %1$d</string>
     <string name="more_options">Mais opções</string>
     <string name="theme_option">Tema</string>

--- a/feature/reading_plan/src/commonMain/composeResources/values/strings.xml
+++ b/feature/reading_plan/src/commonMain/composeResources/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="progress_label">Progress: %1$d %</string>
     <string name="loading">Loading...</string>
     <string name="week_number">Week %1$d</string>
-    <string name="week_progress_description">%1$d/%2$d complete</string>
+    <string name="week_progress_complete">complete</string>
     <string name="day_number">Day %1$d</string>
     <string name="more_options">More options</string>
     <string name="theme_option">Theme</string>

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/di/ReadingPlanModule.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/di/ReadingPlanModule.kt
@@ -11,9 +11,13 @@ import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.FindFirstW
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.GetSelectedReadingPlanFlowUseCase
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.SetSelectedReadingPlanUseCase
 import com.quare.bibleplanner.feature.readingplan.presentation.factory.ReadingPlanStateFactory
+import com.quare.bibleplanner.feature.readingplan.presentation.mapper.CalculateIsFirstUnreadWeekVisible
+import com.quare.bibleplanner.feature.readingplan.presentation.mapper.DeleteProgressMapper
+import com.quare.bibleplanner.feature.readingplan.presentation.mapper.WeeksPlanPresentationMapper
 import com.quare.bibleplanner.feature.readingplan.presentation.viewmodel.ReadingPlanViewModel
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -28,17 +32,9 @@ val readingPlanModule = module {
     factoryOf(::FindFirstWeekWithUnreadBookUseCase).bind<FindFirstWeekWithUnreadBook>()
 
     // Presentation
-    viewModel {
-        ReadingPlanViewModel(
-            factory = get(),
-            getPlansByWeek = get(),
-            getSelectedReadingPlanFlow = get(),
-            initializeBooksIfNeeded = get(),
-            updateDayReadStatus = get(),
-            setSelectedReadingPlan = get(),
-            findFirstWeekWithUnreadBook = get(),
-            calculateBibleProgressUseCase = get(),
-        )
-    }
+    viewModelOf(::ReadingPlanViewModel)
     factoryOf(::ReadingPlanStateFactory)
+    factoryOf(::WeeksPlanPresentationMapper)
+    factoryOf(::CalculateIsFirstUnreadWeekVisible)
+    factoryOf(::DeleteProgressMapper)
 }

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/ReadingPlanScreen.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/ReadingPlanScreen.kt
@@ -1,48 +1,27 @@
 package com.quare.bibleplanner.feature.readingplan.presentation
 
 import androidx.compose.animation.AnimatedContentScope
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Book
-import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FabPosition
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
-import bibleplanner.feature.reading_plan.generated.resources.Res
-import bibleplanner.feature.reading_plan.generated.resources.go_to_unread
-import bibleplanner.feature.reading_plan.generated.resources.more_options
-import bibleplanner.feature.reading_plan.generated.resources.reading_plan
-import bibleplanner.feature.reading_plan.generated.resources.scroll_to_top
-import com.quare.bibleplanner.feature.readingplan.presentation.component.ReadingPlanDropdownMenu
+import com.quare.bibleplanner.feature.readingplan.presentation.component.ReadingPlanTopBar
+import com.quare.bibleplanner.feature.readingplan.presentation.component.fabs.ReadingPlanFabsComponent
 import com.quare.bibleplanner.feature.readingplan.presentation.content.ReadingPlanContent
 import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiEvent
 import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiState
-import com.quare.bibleplanner.ui.component.icon.CommonIconButton
-import org.jetbrains.compose.resources.stringResource
 
 private const val MAX_CONTENT_WIDTH = 600
 
@@ -57,22 +36,6 @@ internal fun ReadingPlanScreen(
     scrollBehavior: TopAppBarScrollBehavior,
     onEvent: (ReadingPlanUiEvent) -> Unit,
 ) {
-    // Determine if the first unread week is visible and expanded
-    // Hide FAB if we're already viewing the first unread week (expanded and at top)
-    val isFirstUnreadWeekVisible = remember(uiState) {
-        if (uiState is ReadingPlanUiState.Loaded) {
-            val firstUnreadWeek = uiState.weekPlans.find { week ->
-                week.weekPlan.days.any { day ->
-                    day.passages.any { passage -> !passage.isRead }
-                }
-            }
-            // If the first unread week is expanded and we're at the top, we're "in" it
-            firstUnreadWeek != null && firstUnreadWeek.isExpanded && !uiState.isScrolledDown
-        } else {
-            false
-        }
-    }
-
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -81,70 +44,14 @@ internal fun ReadingPlanScreen(
             SnackbarHost(hostState = snackbarHostState)
         },
         topBar = {
-            TopAppBar(
-                title = {
-                    Column {
-                        Text(text = stringResource(Res.string.reading_plan))
-                    }
-                },
+            ReadingPlanTopBar(
                 scrollBehavior = scrollBehavior,
-                actions = {
-                    CommonIconButton(
-                        imageVector = Icons.Default.MoreVert,
-                        onClick = {
-                            onEvent(ReadingPlanUiEvent.OnOverflowClick)
-                        },
-                        contentDescription = stringResource(Res.string.more_options),
-                    )
-                    ReadingPlanDropdownMenu(
-                        isShowingMenu = uiState.isShowingMenu,
-                        onEvent = onEvent,
-                    )
-                },
+                isShowingMenu = uiState.isShowingMenu,
+                onEvent = onEvent,
             )
         },
         floatingActionButton = {
-            Column(
-                horizontalAlignment = Alignment.End,
-            ) {
-                // Scroll to top FAB - only visible when scrolled down
-                AnimatedVisibility(
-                    visible = uiState.isScrolledDown,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                ) {
-                    SmallFloatingActionButton(
-                        onClick = {
-                            onEvent(ReadingPlanUiEvent.OnScrollToTopClick)
-                        },
-                        modifier = Modifier.padding(bottom = 8.dp),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.KeyboardArrowUp,
-                            contentDescription = stringResource(Res.string.scroll_to_top),
-                        )
-                    }
-                }
-                // Main FAB - scroll to first unread week
-                // Hide if we're already viewing the first unread week opened
-                if (!isFirstUnreadWeekVisible) {
-                    ExtendedFloatingActionButton(
-                        onClick = {
-                            onEvent(ReadingPlanUiEvent.OnScrollToFirstUnreadWeekClick)
-                        },
-                        expanded = !uiState.isScrolledDown,
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Default.Book,
-                                contentDescription = null,
-                            )
-                        },
-                        text = {
-                            Text(stringResource(Res.string.go_to_unread))
-                        },
-                    )
-                }
-            }
+            ReadingPlanFabsComponent(uiState, onEvent)
         },
         floatingActionButtonPosition = FabPosition.End,
     ) { paddingValues ->

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/ReadingPlanTopBar.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/ReadingPlanTopBar.kt
@@ -1,0 +1,46 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import bibleplanner.feature.reading_plan.generated.resources.Res
+import bibleplanner.feature.reading_plan.generated.resources.more_options
+import bibleplanner.feature.reading_plan.generated.resources.reading_plan
+import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiEvent
+import com.quare.bibleplanner.ui.component.icon.CommonIconButton
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ReadingPlanTopBar(
+    scrollBehavior: TopAppBarScrollBehavior,
+    isShowingMenu: Boolean,
+    onEvent: (ReadingPlanUiEvent) -> Unit,
+) {
+    TopAppBar(
+        title = {
+            Column {
+                Text(text = stringResource(Res.string.reading_plan))
+            }
+        },
+        scrollBehavior = scrollBehavior,
+        actions = {
+            CommonIconButton(
+                imageVector = Icons.Default.MoreVert,
+                onClick = {
+                    onEvent(ReadingPlanUiEvent.OnOverflowClick)
+                },
+                contentDescription = stringResource(Res.string.more_options),
+            )
+            ReadingPlanDropdownMenu(
+                isShowingMenu = isShowingMenu,
+                onEvent = onEvent,
+            )
+        },
+    )
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/fabs/GoToUnreadFab.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/fabs/GoToUnreadFab.kt
@@ -1,0 +1,34 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component.fabs
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import bibleplanner.feature.reading_plan.generated.resources.Res
+import bibleplanner.feature.reading_plan.generated.resources.go_to_unread
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun GoToUnreadFab(
+    modifier: Modifier = Modifier,
+    isExpanded: Boolean,
+    onClick: () -> Unit,
+) {
+    ExtendedFloatingActionButton(
+        modifier = modifier,
+        expanded = isExpanded,
+        text = {
+            Text(stringResource(Res.string.go_to_unread))
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Default.Book,
+                contentDescription = null,
+            )
+        },
+        onClick = onClick,
+    )
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/fabs/ReadingPlanFabsComponent.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/fabs/ReadingPlanFabsComponent.kt
@@ -1,0 +1,35 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component.fabs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiEvent
+import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiState
+
+@Composable
+internal fun ReadingPlanFabsComponent(
+    uiState: ReadingPlanUiState,
+    onEvent: (ReadingPlanUiEvent) -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.End,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ScrollToUpFab(
+            isScrolledDown = uiState.isScrolledDown,
+            onClick = {
+                onEvent(ReadingPlanUiEvent.OnScrollToTopClick)
+            },
+        )
+        if (!uiState.isFirstUnreadWeekVisible) {
+            GoToUnreadFab(
+                isExpanded = !uiState.isScrolledDown,
+                onClick = {
+                    onEvent(ReadingPlanUiEvent.OnScrollToFirstUnreadWeekClick)
+                },
+            )
+        }
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/fabs/ScrollToUpFab.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/fabs/ScrollToUpFab.kt
@@ -1,0 +1,37 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component.fabs
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import bibleplanner.feature.reading_plan.generated.resources.Res
+import bibleplanner.feature.reading_plan.generated.resources.scroll_to_top
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun ScrollToUpFab(
+    modifier: Modifier = Modifier,
+    isScrolledDown: Boolean,
+    onClick: () -> Unit,
+) {
+    AnimatedVisibility(
+        modifier = modifier,
+        visible = isScrolledDown,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        SmallFloatingActionButton(
+            onClick = onClick,
+        ) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowUp,
+                contentDescription = stringResource(Res.string.scroll_to_top),
+            )
+        }
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekPlanItem.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekPlanItem.kt
@@ -1,4 +1,4 @@
-package com.quare.bibleplanner.feature.readingplan.presentation.component
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -11,6 +11,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.quare.bibleplanner.feature.readingplan.presentation.component.week.day.AnimatedDaysList
 import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiEvent
 import com.quare.bibleplanner.feature.readingplan.presentation.model.WeekPlanPresentationModel
 

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekProgressLabel.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekProgressLabel.kt
@@ -1,0 +1,70 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import bibleplanner.feature.reading_plan.generated.resources.Res
+import bibleplanner.feature.reading_plan.generated.resources.week_progress_complete
+import org.jetbrains.compose.resources.stringResource
+
+private const val DAY_PROGRESS_ANIMATION_DURATION_MS = 300
+
+@Composable
+internal fun WeekProgressLabel(
+    readDaysCount: Int,
+    totalDays: Int,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(0.dp),
+    ) {
+        AnimatedContent(
+            targetState = readDaysCount,
+            transitionSpec = {
+                getDayProgressAnimation()
+            },
+            label = "readDaysCountAnimation",
+        ) { count ->
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Text(
+            text = "/$totalDays",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+        )
+        Text(
+            text = " ${stringResource(Res.string.week_progress_complete)}",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+private fun getDayProgressAnimation(): ContentTransform = (
+    fadeIn(animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS)) + slideInVertically(
+        animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS),
+        initialOffsetY = { it },
+    )
+) togetherWith (
+    fadeOut(animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS)) + slideOutVertically(
+        animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS),
+        targetOffsetY = { -it },
+    )
+)

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekRow.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekRow.kt
@@ -1,4 +1,4 @@
-package com.quare.bibleplanner.feature.readingplan.presentation.component
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekText.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekText.kt
@@ -1,4 +1,4 @@
-package com.quare.bibleplanner.feature.readingplan.presentation.component
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -14,7 +14,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import bibleplanner.feature.reading_plan.generated.resources.Res
 import bibleplanner.feature.reading_plan.generated.resources.week_number
-import bibleplanner.feature.reading_plan.generated.resources.week_progress_description
 import com.quare.bibleplanner.core.utils.SharedTransitionAnimationUtils
 import org.jetbrains.compose.resources.stringResource
 
@@ -55,14 +54,6 @@ internal fun SharedTransitionScope.WeekText(
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Medium,
         )
-        Text(
-            text = stringResource(
-                Res.string.week_progress_description,
-                readDaysCount,
-                totalDays,
-            ),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Medium,
-        )
+        WeekProgressLabel(readDaysCount, totalDays)
     }
 }

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/AnimatedDaysList.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/AnimatedDaysList.kt
@@ -1,4 +1,4 @@
-package com.quare.bibleplanner.feature.readingplan.presentation.component
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week.day
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedVisibility

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/DayItem.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/DayItem.kt
@@ -1,4 +1,4 @@
-package com.quare.bibleplanner.feature.readingplan.presentation.component
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week.day
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/content/ReadingPlanContent.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/content/ReadingPlanContent.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.quare.bibleplanner.feature.readingplan.presentation.component.PlanProgress
 import com.quare.bibleplanner.feature.readingplan.presentation.component.PlanTypesSegmentedButtons
-import com.quare.bibleplanner.feature.readingplan.presentation.component.WeekPlanItem
+import com.quare.bibleplanner.feature.readingplan.presentation.component.week.WeekPlanItem
 import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiEvent
 import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiState
 import com.quare.bibleplanner.ui.component.spacer.VerticalSpacer

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/mapper/CalculateIsFirstUnreadWeekVisible.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/mapper/CalculateIsFirstUnreadWeekVisible.kt
@@ -1,0 +1,18 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.mapper
+
+import com.quare.bibleplanner.feature.readingplan.presentation.model.WeekPlanPresentationModel
+
+internal class CalculateIsFirstUnreadWeekVisible {
+    operator fun invoke(
+        weekPlans: List<WeekPlanPresentationModel>,
+        isScrolledDown: Boolean,
+    ): Boolean {
+        val firstUnreadWeek = weekPlans.find { week ->
+            week.weekPlan.days.any { day ->
+                day.passages.any { passage -> !passage.isRead }
+            }
+        }
+        // If the first unread week is expanded and we're at the top, we're "in" it
+        return firstUnreadWeek != null && firstUnreadWeek.isExpanded && !isScrolledDown
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/mapper/DeleteProgressMapper.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/mapper/DeleteProgressMapper.kt
@@ -1,0 +1,21 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.mapper
+
+import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiAction
+import com.quare.bibleplanner.feature.readingplan.presentation.model.ReadingPlanUiState
+import com.quare.bibleplanner.feature.readingplan.presentation.model.WeekPlanPresentationModel
+
+internal class DeleteProgressMapper {
+    fun map(state: ReadingPlanUiState): ReadingPlanUiAction? = when (state) {
+        is ReadingPlanUiState.Loaded -> if (state.weekPlans.containsReadDay()) {
+            ReadingPlanUiAction.GoToDeleteAllProgress
+        } else {
+            ReadingPlanUiAction.ShowNoProgressToDelete
+        }
+
+        is ReadingPlanUiState.Loading -> null
+    }
+
+    private fun List<WeekPlanPresentationModel>.containsReadDay(): Boolean = any {
+        it.weekPlan.days.any { day -> day.isRead }
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/mapper/WeeksPlanPresentationMapper.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/mapper/WeeksPlanPresentationMapper.kt
@@ -1,0 +1,18 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.mapper
+
+import com.quare.bibleplanner.core.model.plan.WeekPlanModel
+import com.quare.bibleplanner.feature.readingplan.presentation.model.WeekPlanPresentationModel
+
+internal class WeeksPlanPresentationMapper {
+    fun map(
+        weeks: List<WeekPlanModel>,
+        expandedWeeks: Set<Int>,
+    ): List<WeekPlanPresentationModel> = weeks.map { week ->
+        WeekPlanPresentationModel(
+            weekPlan = week,
+            isExpanded = expandedWeeks.contains(week.number),
+            readDaysCount = week.days.count { it.isRead },
+            totalDays = week.days.size,
+        )
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/model/ReadingPlanUiState.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/model/ReadingPlanUiState.kt
@@ -8,6 +8,7 @@ internal sealed interface ReadingPlanUiState {
     val scrollToWeekNumber: Int
     val scrollToTop: Boolean
     val isScrolledDown: Boolean
+    val isFirstUnreadWeekVisible: Boolean
 
     data class Loaded(
         val weekPlans: List<WeekPlanPresentationModel>,
@@ -17,6 +18,7 @@ internal sealed interface ReadingPlanUiState {
         override val scrollToWeekNumber: Int = 0,
         override val scrollToTop: Boolean = false,
         override val isScrolledDown: Boolean = false,
+        override val isFirstUnreadWeekVisible: Boolean = false,
     ) : ReadingPlanUiState
 
     data class Loading(
@@ -25,5 +27,6 @@ internal sealed interface ReadingPlanUiState {
         override val scrollToWeekNumber: Int = 0,
         override val scrollToTop: Boolean = false,
         override val isScrolledDown: Boolean = false,
+        override val isFirstUnreadWeekVisible: Boolean = false,
     ) : ReadingPlanUiState
 }


### PR DESCRIPTION
This commit refactors the ReadingPlan feature by extracting UI components into smaller, more focused composables for better organization and readability. Key changes include:

- A new `ReadingPlanFabsComponent` is introduced, which houses a "Scroll to top" FAB and an extended FAB to navigate to the first unread week. These FABs' visibility is dynamically managed based on the scroll state.
- The `ReadingPlanTopBar` and `WeekProgressLabel` have been extracted into their own composables.
- The week progress description has been updated to use a new format, now showing `{count}/{total} complete`.
- Logic has been added to the `ReadingPlanViewModel` to determine the visibility of the first unread week.
- Project structure has been improved by organizing related component files into new `fabs`, `week`, and `day` sub-packages.