### PR TITLE
Feature: Animate progress counters for day progress and centralize logic

### DIFF
--- a/feature/day/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/day/src/commonMain/composeResources/values-es/strings.xml
@@ -3,7 +3,7 @@
     <string name="back">Atrás</string>
     <string name="day_title_part">Día %1$d</string>
     <string name="week_title_part">Semana %1$d</string>
-    <string name="passages_completed">%1$d/%2$d pasajes completados</string>
+    <string name="passages_completed">pasajes completados</string>
     <string name="loading">Cargando...</string>
     <string name="no_date_set">No hay fecha establecida</string>
     <string name="mark_as_unread">Marcar como no leído</string>

--- a/feature/day/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/feature/day/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -3,7 +3,7 @@
     <string name="back">Voltar</string>
     <string name="day_title_part">Dia %1$d</string>
     <string name="week_title_part">Semana %1$d</string>
-    <string name="passages_completed">%1$d/%2$d passagens concluídas</string>
+    <string name="passages_completed">passagens concluídas</string>
     <string name="loading">Carregando...</string>
     <string name="no_date_set">Nenhuma data definida</string>
     <string name="mark_as_unread">Marcar como não lido</string>

--- a/feature/day/src/commonMain/composeResources/values/strings.xml
+++ b/feature/day/src/commonMain/composeResources/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="back">Back</string>
     <string name="day_title_part">Day %1$d</string>
     <string name="week_title_part">Week %1$d</string>
-    <string name="passages_completed">%1$d/%2$d passages completed</string>
+    <string name="passages_completed">passages completed</string>
     <string name="loading">Loading...</string>
     <string name="no_date_set">No date set</string>
     <string name="mark_as_unread">Mark as unread</string>

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/component/DayProgress.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/component/DayProgress.kt
@@ -1,108 +1,41 @@
 package com.quare.bibleplanner.feature.day.presentation.component
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import bibleplanner.feature.day.generated.resources.Res
 import bibleplanner.feature.day.generated.resources.passages_completed
-import com.quare.bibleplanner.core.model.book.BookDataModel
-import com.quare.bibleplanner.core.model.plan.ChapterPlanModel
-import com.quare.bibleplanner.core.model.plan.PassagePlanModel
+import com.quare.bibleplanner.ui.component.AnimatedIntText
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun DayProgress(
-    passages: List<PassagePlanModel>,
-    books: List<BookDataModel>,
+    completedCount: Int,
+    totalCount: Int,
     modifier: Modifier = Modifier,
 ) {
-    val (completedCount, totalCount) = calculateChapterCounts(
-        passages = passages,
-        books = books,
-    )
-
-    Text(
+    Row(
         modifier = modifier,
-        text = stringResource(
-            Res.string.passages_completed,
-            completedCount,
-            totalCount,
-        ),
-        style = MaterialTheme.typography.labelMedium,
-    )
-}
-
-/**
- * Calculate the total number of chapters/items displayed and how many are completed.
- * Returns a Pair of (completedCount, totalCount).
- */
-private fun calculateChapterCounts(
-    passages: List<PassagePlanModel>,
-    books: List<BookDataModel>,
-): Pair<Int, Int> {
-    var totalCount = 0
-    var completedCount = 0
-
-    passages.forEach { passage ->
-        if (passage.chapters.isEmpty()) {
-            // If no chapters specified, count as 1 item (the whole book)
-            totalCount++
-            if (passage.isRead) {
-                completedCount++
-            }
-        } else {
-            // Count each chapter as a separate item
-            passage.chapters.forEach { chapter ->
-                totalCount++
-                val isChapterRead = isChapterReadForCount(
-                    passage = passage,
-                    chapter = chapter,
-                    books = books,
-                )
-                if (isChapterRead) {
-                    completedCount++
-                }
-            }
-        }
-    }
-
-    return Pair(completedCount, totalCount)
-}
-
-/**
- * Check if a specific chapter within a passage is read by checking the book data.
- */
-private fun isChapterReadForCount(
-    passage: PassagePlanModel,
-    chapter: ChapterPlanModel,
-    books: List<BookDataModel>,
-): Boolean {
-    val book = books.find { it.id == passage.bookId } ?: return false
-    val bookChapter = book.chapters.find { it.number == chapter.number } ?: return false
-
-    val startVerse = chapter.startVerse
-    val endVerse = chapter.endVerse
-
-    return when {
-        // If verse range is specified, check those specific verses
-        startVerse != null && endVerse != null -> {
-            val requiredVerses = startVerse..endVerse
-            requiredVerses.all { verseNumber ->
-                bookChapter.verses.find { it.number == verseNumber }?.isRead == true
-            }
-        }
-
-        // If only start verse is specified, check from that verse to end of chapter
-        startVerse != null -> {
-            bookChapter.verses
-                .filter { it.number >= startVerse }
-                .all { it.isRead }
-        }
-
-        // If no verse range specified, check if entire chapter is read
-        else -> {
-            bookChapter.isRead
-        }
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(0.dp),
+    ) {
+        AnimatedIntText(
+            value = completedCount,
+            label = "completedCountAnimation",
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Text(
+            text = "/$totalCount",
+            style = MaterialTheme.typography.labelMedium,
+        )
+        Text(
+            text = " ${stringResource(Res.string.passages_completed)}",
+            style = MaterialTheme.typography.labelMedium,
+        )
     }
 }

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/component/DayScreenTopBarComponent.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/component/DayScreenTopBarComponent.kt
@@ -83,8 +83,8 @@ internal fun DayScreenTopBarComponent(
                     }
                     VerticalSpacer(4)
                     DayProgress(
-                        passages = day.passages,
-                        books = books,
+                        completedCount = completedPassagesCount,
+                        totalCount = totalPassagesCount,
                     )
                 }
             }

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/factory/DayUiStateFlowFactory.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/factory/DayUiStateFlowFactory.kt
@@ -1,5 +1,8 @@
 package com.quare.bibleplanner.feature.day.presentation.factory
 
+import com.quare.bibleplanner.core.model.book.BookDataModel
+import com.quare.bibleplanner.core.model.plan.ChapterPlanModel
+import com.quare.bibleplanner.core.model.plan.PassagePlanModel
 import com.quare.bibleplanner.core.model.plan.ReadingPlanType
 import com.quare.bibleplanner.feature.day.domain.EditDaySelectableDates
 import com.quare.bibleplanner.feature.day.domain.usecase.CalculateAllChaptersReadStatusUseCase
@@ -72,6 +75,11 @@ internal class DayUiStateFlowFactory(
                 )
             }
 
+            val (completedCount, totalCount) = calculatePassageCounts(
+                passages = day.passages,
+                books = books,
+            )
+
             DayUiState.Loaded(
                 day = day,
                 weekNumber = weekNumber,
@@ -82,9 +90,85 @@ internal class DayUiStateFlowFactory(
                     passages = day.passages,
                     books = books,
                 ),
+                completedPassagesCount = completedCount,
+                totalPassagesCount = totalCount,
             )
         } else {
             DayUiState.Loading
+        }
+    }
+
+    /**
+     * Calculate the total number of chapters/items displayed and how many are completed.
+     * Returns a Pair of (completedCount, totalCount).
+     */
+    private fun calculatePassageCounts(
+        passages: List<PassagePlanModel>,
+        books: List<BookDataModel>,
+    ): Pair<Int, Int> {
+        var totalCount = 0
+        var completedCount = 0
+
+        passages.forEach { passage ->
+            if (passage.chapters.isEmpty()) {
+                // If no chapters specified, count as 1 item (the whole book)
+                totalCount++
+                if (passage.isRead) {
+                    completedCount++
+                }
+            } else {
+                // Count each chapter as a separate item
+                passage.chapters.forEach { chapter ->
+                    totalCount++
+                    val isChapterRead = isChapterReadForCount(
+                        passage = passage,
+                        chapter = chapter,
+                        books = books,
+                    )
+                    if (isChapterRead) {
+                        completedCount++
+                    }
+                }
+            }
+        }
+
+        return Pair(completedCount, totalCount)
+    }
+
+    /**
+     * Check if a specific chapter within a passage is read by checking the book data.
+     */
+    private fun isChapterReadForCount(
+        passage: PassagePlanModel,
+        chapter: ChapterPlanModel,
+        books: List<BookDataModel>,
+    ): Boolean {
+        val book = books.find { it.id == passage.bookId } ?: return false
+        val bookChapter = book.chapters.find { it.number == chapter.number } ?: return false
+
+        val startVerse = chapter.startVerse
+        val endVerse = chapter.endVerse
+
+        return when {
+            // If verse range is specified, check those specific verses
+            startVerse != null && endVerse != null -> {
+                val requiredVerses = startVerse..endVerse
+                requiredVerses.all { verseNumber ->
+                    bookChapter.verses.find { it.number == verseNumber }?.isRead == true
+                }
+            }
+
+            // If only start verse is specified, check from that verse to end of chapter
+            startVerse != null -> {
+                bookChapter.verses
+                    .filter { it.number >= startVerse }
+                    .all { it.isRead }
+            }
+
+            // If no verse range specified, check if entire chapter is read
+            else -> {
+                bookChapter.isRead
+            }
         }
     }
 }

--- a/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/model/DayUiState.kt
+++ b/feature/day/src/commonMain/kotlin/com/quare/bibleplanner/feature/day/presentation/model/DayUiState.kt
@@ -13,5 +13,7 @@ internal sealed interface DayUiState {
         val datePickerUiState: DatePickerUiState,
         val formattedReadDate: String?,
         val chapterReadStatus: Map<Pair<Int, Int>, Boolean>,
+        val completedPassagesCount: Int,
+        val totalPassagesCount: Int,
     ) : DayUiState
 }

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekProgressLabel.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/WeekProgressLabel.kt
@@ -1,13 +1,5 @@
 package com.quare.bibleplanner.feature.readingplan.presentation.component.week
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme
@@ -18,9 +10,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import bibleplanner.feature.reading_plan.generated.resources.Res
 import bibleplanner.feature.reading_plan.generated.resources.week_progress_complete
+import com.quare.bibleplanner.ui.component.AnimatedIntText
 import org.jetbrains.compose.resources.stringResource
-
-private const val DAY_PROGRESS_ANIMATION_DURATION_MS = 300
 
 @Composable
 internal fun WeekProgressLabel(
@@ -31,19 +22,11 @@ internal fun WeekProgressLabel(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(0.dp),
     ) {
-        AnimatedContent(
-            targetState = readDaysCount,
-            transitionSpec = {
-                getDayProgressAnimation()
-            },
+        AnimatedIntText(
+            value = readDaysCount,
             label = "readDaysCountAnimation",
-        ) { count ->
-            Text(
-                text = count.toString(),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Medium,
-            )
-        }
+            style = MaterialTheme.typography.titleMedium,
+        )
         Text(
             text = "/$totalDays",
             style = MaterialTheme.typography.titleMedium,
@@ -56,15 +39,3 @@ internal fun WeekProgressLabel(
         )
     }
 }
-
-private fun getDayProgressAnimation(): ContentTransform = (
-    fadeIn(animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS)) + slideInVertically(
-        animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS),
-        initialOffsetY = { it },
-    )
-) togetherWith (
-    fadeOut(animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS)) + slideOutVertically(
-        animationSpec = tween(DAY_PROGRESS_ANIMATION_DURATION_MS),
-        targetOffsetY = { -it },
-    )
-)

--- a/ui/component/src/commonMain/kotlin/com/quare/bibleplanner/ui/component/AnimatedIntText.kt
+++ b/ui/component/src/commonMain/kotlin/com/quare/bibleplanner/ui/component/AnimatedIntText.kt
@@ -1,0 +1,50 @@
+package com.quare.bibleplanner.ui.component
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+fun AnimatedIntText(
+    modifier: Modifier = Modifier,
+    value: Int,
+    label: String,
+    animationDurationMs: Int = 300,
+    style: TextStyle = LocalTextStyle.current,
+) {
+    AnimatedContent(
+        modifier = modifier,
+        targetState = value,
+        transitionSpec = {
+            getProgressAnimation(animationDurationMs)
+        },
+        label = label,
+    ) { count ->
+        Text(
+            text = count.toString(),
+            style = style,
+        )
+    }
+}
+
+private fun getProgressAnimation(durationMs: Int): ContentTransform = (
+    fadeIn(animationSpec = tween(durationMs)) + slideInVertically(
+        animationSpec = tween(durationMs),
+        initialOffsetY = { it },
+    )
+) togetherWith (
+    fadeOut(animationSpec = tween(durationMs)) + slideOutVertically(
+        animationSpec = tween(durationMs),
+        targetOffsetY = { -it },
+    )
+)


### PR DESCRIPTION
This commit introduces an animated progress counter and refactors the way progress is calculated and displayed.

The `passages_completed` string has been updated to remove the numeric placeholders, allowing for a more flexible and animated presentation of the completion count (e.g., "1/5 passages completed").

A new generic `AnimatedIntText` composable has been created in the `ui/component` module. This component is now used in both the `WeekProgressLabel` and the `DayProgress` to animate changes in the progress count, providing a smoother user experience.

The logic for calculating passage and chapter completion, previously duplicated in the `DayProgress` composable, has been moved into the `DayUiStateFlowFactory`. This centralization simplifies the UI components, making them stateless and improving the overall architecture by separating concerns. The `DayUiState` now directly provides the completed and total passage counts to the UI.