### PR TITLE
feat: Set development region to English for iOS

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>Bible Planner</string>
 </dict>


### PR DESCRIPTION
This change sets the `CFBundleDevelopmentRegion` to 'en' in the `Info.plist` file for the iOS app. This specifies that English is the native development language, which helps the system with localization.