### PR TITLE
build: Add Gradle caching to ktlint workflow

### DIFF
--- a/ui/component/src/commonMain/kotlin/com/quare/bibleplanner/ui/component/icon/EditTextButton.kt
+++ b/ui/component/src/commonMain/kotlin/com/quare/bibleplanner/ui/component/icon/EditTextButton.kt
@@ -11,7 +11,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun EditTextButton(
     modifier: Modifier = Modifier,
-    onClick:       () -> Unit,
+    onClick: () -> Unit,
 ) {
     TextButton(
         modifier = modifier,


### PR DESCRIPTION
This change introduces caching for Gradle dependencies and the wrapper in the ktlint GitHub Actions workflow to improve build performance. It also adds a step to display the cache status during the run.