### PR TITLE
Refactor `PlannedReadDateComponent` and introduce `AnimatedPlannedReadDateComponent`

### DIFF
--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/AnimatedDaysList.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/AnimatedDaysList.kt
@@ -34,8 +34,6 @@ internal fun SharedTransitionScope.AnimatedDaysList(
                     DayItem(
                         weekNumber = number,
                         day = day,
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp),
                         onEvent = onEvent,
                         animatedContentScope = animatedContentScope,
                     )

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/AnimatedPlannedReadDateComponent.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/AnimatedPlannedReadDateComponent.kt
@@ -1,0 +1,37 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component.week.day
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.quare.bibleplanner.core.model.plan.DayModel
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+internal fun SharedTransitionScope.AnimatedPlannedReadDateComponent(
+    modifier: Modifier = Modifier,
+    day: DayModel,
+    animatedContentScope: AnimatedContentScope,
+    weekNumber: Int,
+    dayNumber: Int,
+) {
+    AnimatedContent(
+        modifier = modifier,
+        targetState = day.plannedReadDate,
+    ) { plannedReadDate ->
+        if (plannedReadDate != null) {
+            PlannedReadDateComponent(
+                modifier = Modifier.padding(start = 16.dp),
+                plannedReadDate = plannedReadDate,
+                isRead = day.isRead,
+                animatedContentScope = animatedContentScope,
+                weekNumber = weekNumber,
+                dayNumber = dayNumber,
+            )
+        }
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/DayItem.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/DayItem.kt
@@ -1,6 +1,5 @@
 package com.quare.bibleplanner.feature.readingplan.presentation.component.week.day
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
@@ -8,7 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Checkbox
 import androidx.compose.runtime.Composable
@@ -40,7 +38,6 @@ internal fun SharedTransitionScope.DayItem(
             }.padding(vertical = 8.dp),
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -49,20 +46,12 @@ internal fun SharedTransitionScope.DayItem(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                AnimatedContent(
-                    targetState = day.plannedReadDate,
-                ) { plannedReadDate ->
-                    if (plannedReadDate != null) {
-                        PlannedReadDateComponent(
-                            modifier = Modifier,
-                            plannedReadDate = plannedReadDate,
-                            isRead = day.isRead,
-                            animatedContentScope = animatedContentScope,
-                            weekNumber = weekNumber,
-                            dayNumber = dayNumber,
-                        )
-                    }
-                }
+                AnimatedPlannedReadDateComponent(
+                    day = day,
+                    animatedContentScope = animatedContentScope,
+                    weekNumber = weekNumber,
+                    dayNumber = dayNumber,
+                )
                 DayItemTexts(
                     animatedContentScope = animatedContentScope,
                     day = day,
@@ -70,6 +59,7 @@ internal fun SharedTransitionScope.DayItem(
                 )
             }
             Checkbox(
+                modifier = Modifier.padding(end = 8.dp),
                 checked = day.isRead,
                 onCheckedChange = {
                     onEvent(

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/PlannedReadDateComponent.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/week/day/PlannedReadDateComponent.kt
@@ -63,7 +63,7 @@ fun SharedTransitionScope.PlannedReadDateComponent(
                     ),
                     animatedVisibilityScope = animatedContentScope,
                 ),
-                text = "${plannedReadDate.day}",
+                text = plannedReadDate.day.toString().padStart(2, '0'),
                 style = textStyle,
                 textDecoration = textDecoration,
             )


### PR DESCRIPTION
This change extracts the animated date logic into a standalone component and improves the formatting of the day display.

Key changes:
- Created `AnimatedPlannedReadDateComponent` to encapsulate the `AnimatedContent` logic for displaying planned read dates.
- Updated `PlannedReadDateComponent` to format the day string with a leading zero (e.g., "01" instead of "1").
- Refactored `DayItem` to use the new `AnimatedPlannedReadDateComponent` and adjusted its layout padding and alignment.
- Simplified `AnimatedDaysList` by removing redundant horizontal padding from `DayItem`.