### PR TITLE
build: centralize Android SDK version management and update `composeApp` configuration

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.bibleplanner.buildlogic.getAndroidSdkVersions
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -11,15 +12,16 @@ plugins {
 
 // Add project-specific dependencies
 kotlin {
+    val androidSdkVersions = getAndroidSdkVersions()
     androidLibrary {
+        compileSdk = androidSdkVersions.compileSdk
+        minSdk = androidSdkVersions.minSdk
         namespace = "com.quare.bibleplanner.shared"
-        compileSdk = project.property("compileSdkVersion").toString().toInt()
-        minSdk = project.property("minSdkVersion").toString().toInt()
     }
 
     android {
-        compileSdk = project.property("compileSdkVersion").toString().toInt()
-        minSdk = project.property("minSdkVersion").toString().toInt()
+        compileSdk = androidSdkVersions.compileSdk
+        minSdk = androidSdkVersions.minSdk
         namespace = "com.quare.bibleplanner.shared"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,10 +10,6 @@ org.gradle.caching=true
 # Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
-compileSdkVersion=36
-targetSdkVersion=36
-minSdkVersion=26
-jvmTarget=21
 versionCode=7
 versionName=1.3.0
 


### PR DESCRIPTION
This change refactors how Android SDK versions are managed by removing hardcoded properties from `gradle.properties` and introducing a centralized helper function `getAndroidSdkVersions()`. The `composeApp` module has been updated to use this helper, improving maintainability across the build configuration.

Key changes:
- Removed `compileSdkVersion`, `targetSdkVersion`, `minSdkVersion`, and `jvmTarget` from `gradle.properties`.
- Updated `composeApp/build.gradle.kts` to retrieve SDK versions via `com.bibleplanner.buildlogic.getAndroidSdkVersions()`.
- Refactored `androidLibrary` and `android` configuration blocks in `composeApp` to use the new helper for `compileSdk` and `minSdk` instead of project properties.