### PR TITLE
chore: Update dependencies and refactor RevenueCat integration

### DIFF
--- a/build-logic/convention/src/main/kotlin/KotlinMultiplatformConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KotlinMultiplatformConventionPlugin.kt
@@ -37,5 +37,11 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
             //remove expect actual warning
             compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
         }
+
+        pluginManager.withPlugin("com.codingfeline.buildkonfig") {
+            tasks.matching { it.name.contains("ArtProfile") }.configureEach {
+                dependsOn("generateBuildKonfig")
+            }
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.quare.bibleplanner.core.model.NavigationEventBus
 import com.quare.bibleplanner.core.model.route.BibleVersionSelectorRoute
+import com.quare.bibleplanner.core.utils.orFalse
 import com.quare.bibleplanner.notification.AndroidBibleVersionDownloadNotifier
 import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -43,11 +44,14 @@ class MainActivity : ComponentActivity() {
         handleNotificationIntent(intent)
     }
 
-    private fun handleNotificationIntent(intent: Intent) {
-        if (intent.getBooleanExtra(AndroidBibleVersionDownloadNotifier.EXTRA_NAVIGATE_TO_BIBLE_VERSIONS, false)) {
-            get<NavigationEventBus>().send(BibleVersionSelectorRoute)
+    private fun handleNotificationIntent(intent: Intent?) {
+        if (intent?.shouldOpenBibleVersionManager().orFalse()) {
+            viewModel.navigationEventBus.send(BibleVersionSelectorRoute)
         }
     }
+
+    private fun Intent.shouldOpenBibleVersionManager(): Boolean =
+        getBooleanExtra(AndroidBibleVersionDownloadNotifier.EXTRA_NAVIGATE_TO_BIBLE_VERSIONS, false)
 
     @Composable
     private fun getStatusBarStyle(isAppInDarkTheme: Boolean): SystemBarStyle = SystemBarStyle.run {

--- a/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivityViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivityViewModel.kt
@@ -1,10 +1,12 @@
 package com.quare.bibleplanner
 
 import androidx.lifecycle.ViewModel
+import com.quare.bibleplanner.core.model.NavigationEventBus
 import com.quare.bibleplanner.feature.materialyou.domain.usecase.GetIsDynamicColorsEnabledFlow
 
 class MainActivityViewModel(
     getIsDynamicColorsEnabledFlow: GetIsDynamicColorsEnabledFlow,
+    val navigationEventBus: NavigationEventBus,
 ) : ViewModel() {
     val isDynamicColorsEnabledFlow = getIsDynamicColorsEnabledFlow()
 }

--- a/core/provider/billing/build.gradle.kts
+++ b/core/provider/billing/build.gradle.kts
@@ -69,8 +69,8 @@ kotlin {
         val mobileMain by creating {
             dependsOn(commonMain)
             dependencies {
-                api(libs.purchases.core)
-                api(libs.purchases.result)
+                api(libs.revenuecat.core)
+                api(libs.revenuecat.result)
             }
         }
 
@@ -78,17 +78,11 @@ kotlin {
             dependsOn(mobileMain)
             dependencies {
                 implementation(project.dependencies.platform(libs.firebase.bom))
-                api(libs.purchases.core)
-                api(libs.purchases.result)
             }
         }
 
         val iosMain by creating {
             dependsOn(mobileMain)
-            dependencies {
-                implementation(libs.purchases.core)
-                implementation(libs.purchases.result)
-            }
         }
 
         val iosArm64Main by getting {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,12 +3,12 @@
 agp = "9.2.1"
 androidx-activity = "1.13.0"
 androidx-lifecycle = "2.10.0"
-composeHotReload = "1.1.0"
+composeHotReload = "1.1.1"
 coreKtx = "1.18.0"
 kotlin = "2.3.21"
-kotlinx-coroutines = "1.10.2"
+kotlinx-coroutines = "1.11.0"
 ktlint = "14.2.0"
-kotlinx-datetime = "0.7.1"
+kotlinx-datetime = "0.8.0"
 kotlinSerializationJson = "1.11.0"
 navigationComposeMultiplatform = "2.9.2"
 koinVersion = "4.2.1"
@@ -18,15 +18,15 @@ ksp = "2.3.6"
 datasSoreVersion = "1.2.1"
 workManagerVersion = "2.11.2"
 facebookSdk = "18.2.3"
-purchases = "2.10.2+17.55.1"
-buildKonfig = "0.20.0"
+revenuecat = "3.0.1"
+buildKonfig = "0.21.0"
 kermit = "2.1.0"
-ktor = "3.4.3"
+ktor = "3.5.0"
 firebaseBom = "34.13.0"
 googeServices = "4.4.4"
 material3 = "1.9.0"
 materialIconsExtended = "1.7.3"
-composeMultiplatform = "1.10.3"
+composeMultiplatform = "1.11.0"
 supabase = "3.6.0"
 coil = "3.4.0"
 
@@ -78,9 +78,9 @@ facebook-sdk-android = { group = "com.facebook.android", name = "facebook-androi
 # Kermit (logger)
 kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
 
-# Purchases
-purchases-core = { group = "com.revenuecat.purchases", name = "purchases-kmp-core", version.ref = "purchases" }
-purchases-result = { group = "com.revenuecat.purchases", name = "purchases-kmp-result", version.ref = "purchases" }
+# Revenuecat Purchases
+revenuecat-core = { group = "com.revenuecat.purchases", name = "purchases-kmp-core", version.ref = "revenuecat" }
+revenuecat-result = { group = "com.revenuecat.purchases", name = "purchases-kmp-result", version.ref = "revenuecat" }
 
 # Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		CB3FB8DF2F08BA3400334921 /* PurchasesHybridCommon in Frameworks */ = {isa = PBXBuildFile; productRef = CB3FB8DE2F08BA3400334921 /* PurchasesHybridCommon */; };
-		CB3FB8E12F08BA3400334921 /* PurchasesHybridCommonUI in Frameworks */ = {isa = PBXBuildFile; productRef = CB3FB8E02F08BA3400334921 /* PurchasesHybridCommonUI */; };
 		CBAC93C92F09F72D005AB4B5 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = CBAC93C82F09F72D005AB4B5 /* FirebaseAnalytics */; };
 		CBAC93CB2F09F72D005AB4B5 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = CBAC93CA2F09F72D005AB4B5 /* FirebaseAnalyticsCore */; };
 		CBAC93CD2F09F72D005AB4B5 /* FirebaseAnalyticsIdentitySupport in Frameworks */ = {isa = PBXBuildFile; productRef = CBAC93CC2F09F72D005AB4B5 /* FirebaseAnalyticsIdentitySupport */; };
@@ -119,10 +117,8 @@
 			files = (
 				CBAC93D92F09F72D005AB4B5 /* FirebaseRemoteConfig in Frameworks */,
 				CBAC93D12F09F72D005AB4B5 /* FirebaseAppDistribution-Beta in Frameworks */,
-				CB3FB8E12F08BA3400334921 /* PurchasesHybridCommonUI in Frameworks */,
 				CBAC93D72F09F72D005AB4B5 /* FirebasePerformance in Frameworks */,
 				CBAC93CD2F09F72D005AB4B5 /* FirebaseAnalyticsIdentitySupport in Frameworks */,
-				CB3FB8DF2F08BA3400334921 /* PurchasesHybridCommon in Frameworks */,
 				CBAC93C92F09F72D005AB4B5 /* FirebaseAnalytics in Frameworks */,
 				CBAC93CF2F09F72D005AB4B5 /* FirebaseAppCheck in Frameworks */,
 				CBAC93D52F09F72D005AB4B5 /* FirebaseCrashlytics in Frameworks */,
@@ -186,8 +182,6 @@
 			);
 			name = iosApp;
 			packageProductDependencies = (
-				CB3FB8DE2F08BA3400334921 /* PurchasesHybridCommon */,
-				CB3FB8E02F08BA3400334921 /* PurchasesHybridCommonUI */,
 				CBAC93C82F09F72D005AB4B5 /* FirebaseAnalytics */,
 				CBAC93CA2F09F72D005AB4B5 /* FirebaseAnalyticsCore */,
 				CBAC93CC2F09F72D005AB4B5 /* FirebaseAnalyticsIdentitySupport */,
@@ -254,7 +248,6 @@
 			mainGroup = 09D6A778CFF1EFA38CC9DCF5;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				CB3FB8DD2F08BA3400334921 /* XCRemoteSwiftPackageReference "purchases-hybrid-common" */,
 				CBAC93C72F09F72D005AB4B5 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -611,14 +604,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		CB3FB8DD2F08BA3400334921 /* XCRemoteSwiftPackageReference "purchases-hybrid-common" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/RevenueCat/purchases-hybrid-common";
-			requirement = {
-				kind = exactVersion;
-				version = 17.55.1;
-			};
-		};
 		CBAC93C72F09F72D005AB4B5 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -630,16 +615,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		CB3FB8DE2F08BA3400334921 /* PurchasesHybridCommon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CB3FB8DD2F08BA3400334921 /* XCRemoteSwiftPackageReference "purchases-hybrid-common" */;
-			productName = PurchasesHybridCommon;
-		};
-		CB3FB8E02F08BA3400334921 /* PurchasesHybridCommonUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CB3FB8DD2F08BA3400334921 /* XCRemoteSwiftPackageReference "purchases-hybrid-common" */;
-			productName = PurchasesHybridCommonUI;
-		};
 		CBAC93C82F09F72D005AB4B5 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CBAC93C72F09F72D005AB4B5 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d847e614dcf9f9bed267b2e7d2b5a4e944a735a7f70763840871e3aa0807c9e3",
+  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -116,24 +116,6 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
-      }
-    },
-    {
-      "identity" : "purchases-hybrid-common",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/RevenueCat/purchases-hybrid-common",
-      "state" : {
-        "revision" : "aa2bfca14cb6e393a9b2a813a4eed770544b2193",
-        "version" : "17.55.1"
-      }
-    },
-    {
-      "identity" : "purchases-ios-spm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/RevenueCat/purchases-ios-spm",
-      "state" : {
-        "revision" : "66f81c19e29170cecc1f155c62cd586cf53b8400",
-        "version" : "5.67.1"
       }
     }
   ],


### PR DESCRIPTION
Updated several library versions across the project, including Compose Multiplatform (1.11.0), kotlinx-coroutines (1.11.0), Ktor (3.5.0), BuildKonfig (0.21.0), and kotlinx-datetime (0.8.0).

Refactored the billing module and iOS project to remove direct Swift Package Manager dependencies on `purchases-hybrid-common` and `purchases-ios-spm`, updating the consolidated RevenueCat library version to 3.0.1.

Modified `KotlinMultiplatformConventionPlugin` to ensure tasks matching "ArtProfile" depend on `generateBuildKonfig` when the BuildKonfig plugin is applied.