### PR TITLE
Fix: white space in top-bar

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -73,6 +73,7 @@ kotlin {
             api(projects.core.provider.room)
             api(projects.core.provider.supabase)
             api(projects.core.provider.billing)
+            api(projects.core.utils)
 
             // UI
             api(projects.ui.theme)

--- a/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivity.kt
@@ -6,16 +6,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import com.quare.bibleplanner.core.model.NavigationEventBus
 import com.quare.bibleplanner.core.model.route.BibleVersionSelectorRoute
 import com.quare.bibleplanner.core.utils.orFalse
 import com.quare.bibleplanner.notification.AndroidBibleVersionDownloadNotifier
-import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : ComponentActivity() {
@@ -53,7 +50,6 @@ class MainActivity : ComponentActivity() {
     private fun Intent.shouldOpenBibleVersionManager(): Boolean =
         getBooleanExtra(AndroidBibleVersionDownloadNotifier.EXTRA_NAVIGATE_TO_BIBLE_VERSIONS, false)
 
-    @Composable
     private fun getStatusBarStyle(isAppInDarkTheme: Boolean): SystemBarStyle = SystemBarStyle.run {
         val color = Color.Transparent.toArgb()
         if (isAppInDarkTheme) {

--- a/feature/books/src/commonMain/kotlin/com/quare/bibleplanner/feature/books/presentation/BooksScreen.kt
+++ b/feature/books/src/commonMain/kotlin/com/quare/bibleplanner/feature/books/presentation/BooksScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.material3.CircularProgressIndicator
@@ -41,7 +40,6 @@ fun BooksScreen(
     Scaffold(
         topBar = {
             BooksTopBar(
-                modifier = Modifier.navigationBarsPadding(),
                 state = state,
                 onEvent = onEvent,
                 contentPadding = mainPadding,

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
@@ -1,4 +1,7 @@
 {
+  "1.13.0": [
+    "Fix extra whitespace below the search bar on the books screen."
+  ],
   "1.12.0": [
     "Notifications about the download progress of Bible versions."
   ],

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
@@ -1,4 +1,7 @@
 {
+  "1.13.0": [
+    "Corrección del espacio en blanco extra debajo de la barra de búsqueda en la pantalla de libros."
+  ],
   "1.12.0": [
     "Notificaciones sobre el progreso de la descarga de las versiones de la Biblia."
   ],

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
@@ -1,4 +1,7 @@
 {
+  "1.13.0": [
+    "Correção do espaço em branco extra abaixo da barra de pesquisa na tela de livros."
+  ],
   "1.12.0": [
     "Notificações sobre progresso de download de versões da biblia."
   ],


### PR DESCRIPTION
Removed unnecessary `navigationBarsPadding` from `BooksTopBar` in `BooksScreen`. Cleaned up unused imports and removed an incorrect `@Composable` annotation from `getStatusBarStyle` in `MainActivity`. Added the `core.utils` project dependency to the `composeApp` build configuration.