### PR TITLE
refactor: update create-pr and release-notes-updater skills

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: create-pr
+description: "Create a pull request following all project conventions: Conventional Commits title, description template, assignee, and labels."
+---
+
+# Create PR
+
+This skill formats the code, commits any uncommitted changes, pushes the branch, and opens a pull
+request with a clear title and description inferred from the actual changes.
+
+## Step-by-step workflow
+
+### 1. Gather context
+
+Run these in parallel:
+- `git status -s` to check for uncommitted changes
+- `git diff --stat` to see unstaged changes
+- `git log --oneline -1` to get the latest commit
+- `git rev-parse --abbrev-ref HEAD` to get the current branch name
+- `git log --oneline develop..HEAD` to see all commits on this branch
+- `git diff develop...HEAD --stat` to see total changes vs develop
+
+### 2. Run ktlint formatter
+
+Run from the project root:
+
+```bash
+./gradlew ktlintFormat
+```
+
+If the command exits with a non-zero code, stop and notify the user:
+> "ktlint found issues it couldn't fix automatically. Please review and fix the reported errors, then try again."
+
+Do not proceed until the formatter succeeds.
+
+### 3. Check the current branch
+
+```bash
+git branch --show-current
+```
+
+Also check the upstream tracking branch:
+
+```bash
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
+```
+
+**If the current branch is `develop`**, or the upstream tracking branch is `origin/develop`, the
+user is working directly on develop — a new branch must be created before committing. Continue to
+step 4 to determine the prefix, then create the branch in step 5.
+
+**If the current branch is already a feature/fix/enhancement/refactor branch**, skip branch
+creation and go directly to step 5.
+
+### 4. Infer the change type
+
+Inspect the uncommitted changes and any commits ahead of origin/develop to understand what kind of
+change this is:
+
+```bash
+git remote update
+git diff HEAD
+git log origin/develop..HEAD --oneline
+```
+
+Based on the changes, choose the most appropriate type:
+
+| Type | When to use |
+|---|---|
+| `fix` | Corrects a bug or unintended behavior |
+| `feature` | Adds new functionality visible to the user |
+| `enhancement` | Improves existing functionality (performance, UX, accessibility) |
+| `refactor` | Internal code restructuring with no user-facing change |
+
+If the changes clearly point to one type, use it without asking.
+If it's genuinely ambiguous, ask the user:
+> "What type of change is this?"
+> - Bug fix
+> - New feature
+> - Improvement to something existing
+> - Internal code cleanup (no visible change)
+
+### 5. Create a new branch (if needed)
+
+If the user is on `develop` (determined in step 3), create and switch to a new branch. Derive the
+branch name from the changes — keep it short, lowercase, hyphen-separated:
+
+```bash
+git checkout -b <type>/<short-description>
+```
+
+Examples:
+- `fix/whitespace-below-search-bar`
+- `feature/offline-bible-reading`
+- `enhancement/books-screen-filters`
+- `refactor/release-notes-viewmodel`
+
+### 6. Update release notes (if user-facing)
+
+Before committing, decide whether the change is user-facing:
+
+- **Run the release-notes-updater skill** if the type is `fix`, `feature`, or `enhancement` AND
+  the change has a visible impact on the user (UI, behavior, new screen, crash fix, etc.)
+- **Skip it** if the type is `refactor`, or if the change is purely internal with no perceptible
+  effect on the user (e.g. dependency update, build config, architecture cleanup, test additions)
+
+When in doubt, lean toward running the skill — it's better to have an extra release note than
+to miss a user-facing change.
+
+Invoke the skill by following the instructions in `docs/skills/release-notes-updater.md`. The
+changes inferred in step 3 should be enough context — pass them along so the skill doesn't need
+to re-run the git commands.
+
+### 7. Commit all uncommitted changes
+
+If the release-notes-updater skill was run in step 6, show the user what was written and ask:
+> "The release notes have been updated. Want me to commit now?"
+
+Wait for confirmation before proceeding. If the user wants to adjust the notes first, let them — then ask again.
+
+Stage everything (including any release notes updates) and create a single commit:
+
+```bash
+git add -A
+git commit -m "<type>: <short description>"
+```
+
+The commit message must:
+- Start with the type prefix (`fix:`, `feature:`, `enhancement:`, `refactor:`)
+- Be concise and in the imperative form (e.g. "fix: remove extra whitespace below search bar")
+- Not exceed 72 characters
+
+If there are no uncommitted changes (the user already committed everything), skip this step.
+
+### 8. Push the branch
+
+```bash
+git push -u origin HEAD
+```
+
+### 9. Create the pull request
+
+First, check if the GitHub CLI is available:
+
+```bash
+gh --version
+```
+
+**If `gh` is not installed**, suggest installing it and ask before proceeding:
+> "GitHub CLI (`gh`) is not installed. Would you like me to install it now?"
+
+If the user agrees, install it:
+```bash
+# macOS
+brew install gh
+```
+
+After installation, authenticate if needed:
+```bash
+gh auth status || gh auth login
+```
+
+Once `gh` is available, create the PR:
+
+```bash
+gh pr create \
+  --base develop \
+  --title "<type>: <short description>" \
+  --body "<description>" \
+  --assignee @me \
+  --label "<label>"
+```
+
+Choose the label based on the change type:
+
+| Type | Label |
+|---|---|
+| `fix` | `bug` |
+| `feature` | `feature` |
+| `enhancement` | `enhancement` |
+| `refactor` | `refactor` |
+
+**Title:** Same format as the commit message — type prefix + short imperative description.
+
+**Description:** Write a clear summary of what changed and why, at a medium level of detail:
+- Describe the problem being solved or the feature being added
+- Mention the affected screens or areas of the app
+- Explain the approach taken if it is not obvious
+- Do NOT list every file changed or describe code line by line
+- Do NOT include purely internal implementation details (e.g. which class was refactored)
+- Keep it to 3–8 sentences or a short bullet list
+
+## Example
+
+Given uncommitted changes that remove a `navigationBarsPadding()` modifier from a top bar:
+
+- **Branch:** `fix/extra-whitespace-below-search-bar`
+- **Commit:** `fix: remove extra whitespace below search bar on books screen`
+- **PR title:** `fix: remove extra whitespace below search bar on books screen`
+- **PR description:**
+  > The books screen had extra whitespace appearing below the search bar due to `navigationBarsPadding()` being applied to the top bar instead of the screen content. This modifier adds padding matching the system navigation bar height, which caused the top bar surface to grow downward unnecessarily. Removed the modifier from the top bar to fix the layout.
+
+## Edge cases
+
+- If ktlint fails, stop immediately — do not commit or push
+- If the user is already on a correctly prefixed branch, skip branch creation
+- If there is nothing to commit and the branch is already pushed, go directly to PR creation
+- If the branch already has an open PR, notify the user instead of creating a duplicate
+- Always target `develop` as the base branch for the PR
+- Release notes updates (step 6) are included in the same commit as the rest of the changes — do not create a separate commit for them

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -20,9 +20,11 @@ Run these in parallel:
 - `git log --oneline develop..HEAD` to see all commits on this branch
 - `git diff develop...HEAD --stat` to see total changes vs develop
 
-### 2. Run ktlint formatter
+### 2. Run ktlint formatter (if needed)
 
-Run from the project root:
+Check whether any `.kt` or `.kts` files are among the changed files gathered in step 1. If none are present, skip this step entirely.
+
+If there are Kotlin files changed, run from the project root:
 
 ```bash
 ./gradlew ktlintFormat

--- a/.claude/skills/release-notes-updater/SKILL.md
+++ b/.claude/skills/release-notes-updater/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: release-notes-updater
+description: "Update the pt.json, en.json, and es.json release notes files with user-friendly descriptions of what changed in the new app version."
+---
+
+# Release Notes Updater
+
+This skill updates the three release notes JSON files (`pt.json`, `en.json`, `es.json`) that are
+displayed directly to users inside the app. The notes need to be clear and friendly — avoid jargon
+and write as if explaining to someone who uses the app but knows nothing about software development.
+
+## JSON file locations
+
+The source files are always at:
+```
+feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
+feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
+feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
+```
+
+## JSON structure
+
+Each file is a JSON object where:
+- Keys are version strings like `"1.13.0"`, ordered from newest to oldest
+- Values are arrays of user-facing strings describing what changed
+
+```json
+{
+  "1.13.0": [
+    "Fix extra whitespace below the search bar on the books screen."
+  ],
+  "1.12.0": [
+    "Notifications about the download progress of Bible versions."
+  ]
+}
+```
+
+## Step-by-step workflow
+
+### 1. Find the latest published release via git tag
+
+Run the following command in the project root to get the latest version tag:
+
+```bash
+git tag --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+```
+
+This returns the highest semver tag (e.g. `v1.12.0` or `1.12.0`).
+Strip the leading `"v"` if present to get a clean version like `"1.12.0"`.
+
+If the command fails or returns nothing (no tags yet), ask the user:
+> "No version tags found in the repository. What is the latest released version?"
+
+### 2. Read the JSON files and find the highest version
+
+Read all three JSON files. Parse the keys as semver versions and find the highest one across the files.
+A version `A` is higher than version `B` if, comparing major.minor.patch numerically, any component
+of `A` is greater at the first differing position.
+
+### 3. Decide whether to create a new version entry or use an existing one
+
+**Case A — The highest version in the JSONs is already greater than the latest git tag:**
+A "next version" slot already exists (e.g. `"1.13.0"` exists while the last tag is `"1.12.0"`).
+Use that version. If its notes array is empty or the user wants to add more items, proceed to step 4.
+
+**Case B — The highest version in the JSONs is equal to or less than the latest git tag:**
+There is no next-version slot yet. Ask the user:
+> "What kind of update is this new version?"
+
+Options:
+- **New feature** (minor) — new functionality added to the app
+- **Bug fix** (patch) — fixes only, no new features
+- **Major update** (major) — significant changes to how the app works
+
+Then compute the new version string by bumping the corresponding semver component of the latest
+tag (major → X+1.0.0, minor → X.Y+1.0, patch → X.Y.Z+1).
+
+### 4. Collect the release notes
+
+First, try to infer the changes automatically by running these commands in the project root:
+
+```bash
+# Sync remote refs
+git remote update
+
+# Committed changes not yet in origin/develop
+git log origin/develop..HEAD --oneline
+
+# Uncommitted changes (staged and unstaged)
+git diff HEAD
+```
+
+Use the commit messages and diff output to figure out what changed from a user's perspective.
+If you can extract meaningful changes from this output, proceed directly to step 5 — do not ask the user.
+
+Only ask the user if:
+- Both commands return nothing (no commits ahead of origin/develop and no uncommitted changes), or
+- The output is too ambiguous to determine what actually changed for the user
+
+In that case, ask:
+> "What changed in this version? Describe it simply, as you would explain it to someone who just uses the app."
+
+If the user already described the changes earlier in the conversation, use that — don't run the commands or ask again.
+
+### 5. Write user-friendly notes in three languages
+
+Transform the user's description into polished, user-facing sentences. The golden rules:
+
+- **No jargon**: say "search bar" not "SearchBar component"; say "books screen" not "BooksScreen"; say "fixed a problem" not "bug fix" or "null pointer exception"
+- **Short and clear**: one sentence per change, starting with an action verb
+- **User's perspective**: describe what they *experience*, not what changed in the code
+- **Positive framing**: "You can now..." or "Fixed an issue that..." instead of dry technical descriptions
+- **Omit internal changes**: refactors, architecture changes, and dependency updates that have no visible user impact should be skipped entirely
+
+Write the notes in all three languages:
+- **pt** (Portuguese — Brazil)
+- **en** (English)
+- **es** (Spanish — Latin America)
+
+Read a few existing entries in each file to calibrate the style and tone before writing.
+
+### 6. Update the JSON files
+
+- Place the version entry at the **top** of each JSON file (versions are ordered newest → oldest)
+- If the version slot already existed with some notes, **append** the new items to the existing array
+- Edit all three files: `pt.json`, `en.json`, `es.json`
+- Confirm briefly to the user what was added and in which version
+
+## Example transformations
+
+| Developer says (raw) | Written in the JSON |
+|---|---|
+| "removed extra whitespace below the search bar on the books screen" | "Fixed extra whitespace that appeared below the search bar on the books screen." |
+| "added download progress notifications for bible versions" | "You now receive notifications about the download progress of Bible versions." |
+| "refactored MoreScreen for better usability" | "The 'More' screen has been reorganized to be easier to use." |
+| "fix null pointer on offline mode" | "Fixed an issue that could crash the app when used without an internet connection." |
+| "migrated ViewModel from LiveData to StateFlow" | *(omit — internal change with no visible user impact)* |
+
+## Edge cases
+
+- If the user provides notes for multiple changes at once, create one array item per change
+- If a version slot exists in `en.json` but not in `pt.json` or `es.json`, create it in the missing files too
+- If the user says the version is already decided (e.g. "it will be 1.14.0"), use that version directly without asking
+- After writing, do not modify any version entry other than the one being worked on


### PR DESCRIPTION
The create-pr and release-notes-updater skill files were added and configured with project conventions.

The create-pr skill now: gathers full context before starting (git status, diff, log, branch); assigns @me automatically; applies the correct GitHub label based on change type (bug, feature, enhancement, refactor); and asks for confirmation before committing when release notes were updated.

The release-notes-updater skill now has a proper description in its frontmatter.