### PR TITLE
refactor: add squash and switch to main step to create-pr skill

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -202,6 +202,33 @@ Given uncommitted changes that remove a `navigationBarsPadding()` modifier from 
 - **PR description:**
   > The books screen had extra whitespace appearing below the search bar due to `navigationBarsPadding()` being applied to the top bar instead of the screen content. This modifier adds padding matching the system navigation bar height, which caused the top bar surface to grow downward unnecessarily. Removed the modifier from the top bar to fix the layout.
 
+### 10. Squash and switch to main (optional)
+
+After the PR is created, ask the user:
+> "Do you want to squash merge this branch into origin/main now?"
+
+If the user agrees, proceed with the following steps in order:
+
+**Squash merge via GitHub CLI:**
+```bash
+gh pr merge --squash --auto
+```
+
+If the merge fails (e.g. pending reviews, CI checks not passed), notify the user and stop:
+> "Could not squash merge right now. Make sure the PR has passed all required checks and try again."
+
+**Update remote refs:**
+```bash
+git remote update
+```
+
+**Switch to origin/main:**
+```bash
+git checkout origin/main
+```
+
+If the user declines, skip this step entirely and end the workflow.
+
 ## Edge cases
 
 - If ktlint fails, stop immediately — do not commit or push


### PR DESCRIPTION
The create-pr skill now includes an optional step 10 after the PR is created: it asks the user whether to squash merge the branch into origin/main. If confirmed, it runs `gh pr merge --squash --auto`, then `git remote update`, and finally `git checkout origin/main` to land cleanly on the updated main branch.