### PR TITLE
refactor: use AskUserQuestion menu for squash prompt in create-pr skill

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -204,8 +204,12 @@ Given uncommitted changes that remove a `navigationBarsPadding()` modifier from 
 
 ### 10. Squash and switch to main (optional)
 
-After the PR is created, ask the user:
-> "Do you want to squash merge this branch into origin/main now?"
+After the PR is created, use the `AskUserQuestion` tool to ask the user with a menu:
+
+- **Question:** "Do you want to squash merge this branch into origin/main now?"
+- **Options:**
+  - Yes — squash merge, update remote refs, and switch to origin/main
+  - No — end the workflow here
 
 If the user agrees, proceed with the following steps in order:
 


### PR DESCRIPTION
The squash merge prompt in step 10 of the create-pr skill now uses the `AskUserQuestion` tool instead of a plain text question, giving the user a proper Yes/No menu to confirm or decline the squash merge.