### PR TITLE
feature: add in-app language switching

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     // Features
     implementation(projects.feature.materialYou)
     implementation(projects.feature.preferences.themeSelection)
+    implementation(projects.feature.preferences.appLanguage)
     implementation(projects.feature.readingPlan)
     implementation(projects.feature.day)
     implementation(projects.feature.deleteProgress)

--- a/androidApp/src/main/kotlin/com/quare/bibleplanner/MainApplication.kt
+++ b/androidApp/src/main/kotlin/com/quare/bibleplanner/MainApplication.kt
@@ -5,6 +5,7 @@ import android.content.pm.ApplicationInfo
 import com.quare.bibleplanner.core.provider.billing.configureRevenueCat
 import com.quare.bibleplanner.di.androidModule
 import com.quare.bibleplanner.di.initializeKoin
+import com.quare.bibleplanner.feature.applanguage.di.androidAppLanguageModule
 import com.quare.bibleplanner.notification.AndroidNotificationStringProvider
 import com.quare.bibleplanner.notification.NotificationStringProvider
 import org.koin.android.ext.koin.androidContext
@@ -27,7 +28,7 @@ class MainApplication : Application() {
             config = {
                 androidContext(context)
             },
-            platformModules = listOf(androidModule, mainApplicationModule),
+            platformModules = listOf(androidModule, mainApplicationModule, androidAppLanguageModule),
         )
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
             api(projects.feature.deleteProgress)
             api(projects.feature.preferences.editPlanStartDate)
             api(projects.feature.preferences.bibleVersion)
+            api(projects.feature.preferences.appLanguage)
 
             // Core
             api(projects.core.books)

--- a/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/quare/bibleplanner/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.quare.bibleplanner
 
+import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -14,9 +16,25 @@ import com.quare.bibleplanner.core.model.route.BibleVersionSelectorRoute
 import com.quare.bibleplanner.core.utils.orFalse
 import com.quare.bibleplanner.notification.AndroidBibleVersionDownloadNotifier
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.util.Locale
 
 class MainActivity : ComponentActivity() {
     private val viewModel: MainActivityViewModel by viewModel()
+
+    override fun attachBaseContext(newBase: Context) {
+        val localeTag = newBase
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_APP_LANGUAGE, null)
+        if (localeTag != null) {
+            val locale = Locale.forLanguageTag(localeTag)
+            Locale.setDefault(locale)
+            val config = Configuration(newBase.resources.configuration)
+            config.setLocale(locale)
+            super.attachBaseContext(newBase.createConfigurationContext(config))
+        } else {
+            super.attachBaseContext(newBase)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +67,11 @@ class MainActivity : ComponentActivity() {
 
     private fun Intent.shouldOpenBibleVersionManager(): Boolean =
         getBooleanExtra(AndroidBibleVersionDownloadNotifier.EXTRA_NAVIGATE_TO_BIBLE_VERSIONS, false)
+
+    companion object {
+        private const val PREFS_NAME = "app_prefs"
+        private const val KEY_APP_LANGUAGE = "app_language"
+    }
 
     private fun getStatusBarStyle(isAppInDarkTheme: Boolean): SystemBarStyle = SystemBarStyle.run {
         val color = Color.Transparent.toArgb()

--- a/composeApp/src/commonMain/kotlin/com/quare/bibleplanner/domain/usecase/impl/InitializeAppContentUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/quare/bibleplanner/domain/usecase/impl/InitializeAppContentUseCase.kt
@@ -4,6 +4,7 @@ import com.quare.bibleplanner.core.books.domain.usecase.InitializeBibleVersionsU
 import com.quare.bibleplanner.core.books.domain.usecase.InitializeBooksIfNeededUseCase
 import com.quare.bibleplanner.core.remoteconfig.domain.service.RemoteConfigService
 import com.quare.bibleplanner.domain.usecase.InitializeAppContent
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.ObserveAppLocale
 import com.quare.bibleplanner.feature.bibleversion.domain.usecase.ObserveSelectedVersionUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -15,6 +16,7 @@ internal class InitializeAppContentUseCase(
     private val initializeBibleVersions: InitializeBibleVersionsUseCase,
     private val ensureStartDateIsAvailable: EnsureStartDateIsAvailableUseCase,
     private val observeSelectedVersion: ObserveSelectedVersionUseCase,
+    private val observeAppLocale: ObserveAppLocale,
     private val remoteConfig: RemoteConfigService, // Don't delete it, it is necessary to initialize remote config
 ) : InitializeAppContent {
     override operator fun invoke(coroutineScope: CoroutineScope) {
@@ -27,6 +29,7 @@ internal class InitializeAppContentUseCase(
                 initializeBibleVersionsDeferred,
                 ensureStartDateDeferred,
             ).joinAll()
+            launch { observeAppLocale() }
             observeSelectedVersion()
         }
     }

--- a/composeApp/src/iosMain/kotlin/com/quare/bibleplanner/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/quare/bibleplanner/MainViewController.kt
@@ -8,6 +8,7 @@ import com.quare.bibleplanner.core.provider.billing.configureRevenueCat
 import com.quare.bibleplanner.core.provider.room.db.getDatabaseBuilder
 import com.quare.bibleplanner.core.remoteconfig.domain.service.RemoteConfigService
 import com.quare.bibleplanner.di.initializeKoin
+import com.quare.bibleplanner.feature.applanguage.di.iosAppLanguageModule
 import com.quare.bibleplanner.notification.IosBibleVersionDownloadNotifier
 import com.quare.bibleplanner.worker.IosBackgroundDownloadBridge
 import com.quare.bibleplanner.worker.IosBibleVersionDownloaderFacade
@@ -38,6 +39,7 @@ fun initializeKoinForIos(
     try {
         initializeKoin(
             platformModules = listOf(
+                iosAppLanguageModule,
                 module {
                     single { getDatabaseBuilder() }
                     single { remoteConfigService }

--- a/composeApp/src/jvmMain/kotlin/com/quare/bibleplanner/Main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/quare/bibleplanner/Main.kt
@@ -8,10 +8,14 @@ import com.quare.bibleplanner.core.books.domain.BibleVersionDownloadNotifier
 import com.quare.bibleplanner.core.books.domain.BibleVersionDownloaderFacade
 import com.quare.bibleplanner.core.provider.room.db.getDatabaseBuilder
 import com.quare.bibleplanner.di.initializeKoin
+import com.quare.bibleplanner.feature.applanguage.di.jvmAppLanguageModule
+import com.quare.bibleplanner.feature.applanguage.presentation.initAppLocale
 import com.quare.bibleplanner.feature.bibleversion.domain.InProcessBibleVersionDownloader
 import com.quare.bibleplanner.notification.DesktopBibleVersionDownloadNotifier
 import com.quare.bibleplanner.worker.DesktopBibleVersionDownloaderFacade
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.stringResource
+import org.koin.core.context.GlobalContext
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -19,6 +23,7 @@ import org.koin.dsl.module
 fun main() = application {
     initializeKoin(
         platformModules = listOf(
+            jvmAppLanguageModule,
             module {
                 single { getDatabaseBuilder() }
                 singleOf(::DesktopBibleVersionDownloadNotifier).bind<BibleVersionDownloadNotifier>()
@@ -27,6 +32,13 @@ fun main() = application {
             },
         ),
     )
+    runBlocking {
+        val koin = GlobalContext.get()
+        initAppLocale(
+            getAppLanguageFlow = koin.get(),
+            applyLocale = koin.get(),
+        )
+    }
     Window(
         onCloseRequest = ::exitApplication,
         title = stringResource(Res.string.app_title),

--- a/core/model/src/commonMain/kotlin/com/quare/bibleplanner/core/model/route/AppLanguageNavRoute.kt
+++ b/core/model/src/commonMain/kotlin/com/quare/bibleplanner/core/model/route/AppLanguageNavRoute.kt
@@ -1,0 +1,6 @@
+package com.quare.bibleplanner.core.model.route
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object AppLanguageNavRoute

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
             implementation(projects.feature.donation.pixQr)
             implementation(projects.feature.login)
             implementation(projects.feature.preferences.bibleVersion)
+            implementation(projects.feature.preferences.appLanguage)
             implementation(projects.feature.read)
             implementation(projects.feature.notificationPermission)
 

--- a/core/navigation/src/commonMain/kotlin/com/quare/bibleplanner/core/navigation/RootAppNavHost.kt
+++ b/core/navigation/src/commonMain/kotlin/com/quare/bibleplanner/core/navigation/RootAppNavHost.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.rememberNavController
 import com.quare.bibleplanner.core.model.NavigationEventBus
 import com.quare.bibleplanner.core.model.route.MainNavRoute
 import com.quare.bibleplanner.feature.addnotesfreewarning.presentation.addNotesFreeWarning
+import com.quare.bibleplanner.feature.applanguage.presentation.appLanguage
 import com.quare.bibleplanner.feature.bibleversion.presentation.bibleVersionSelectionRoot
 import com.quare.bibleplanner.feature.bookdetails.presentation.bookDetails
 import com.quare.bibleplanner.feature.congrats.presentation.congrats
@@ -59,6 +60,7 @@ fun RootAppNavHost() {
             donation(navController)
             pixQr(navController)
             bookDetails(navController, sharedTransitionScope)
+            appLanguage(navController)
             bibleVersionSelectionRoot(navController)
             deleteVersion(navController)
             read(

--- a/core/provider/koin/build.gradle.kts
+++ b/core/provider/koin/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
             implementation(projects.feature.donation)
             implementation(projects.feature.donation.pixQr)
             implementation(projects.feature.preferences.bibleVersion)
+            implementation(projects.feature.preferences.appLanguage)
             implementation(projects.feature.read)
             implementation(projects.feature.notificationPermission)
 

--- a/core/provider/koin/src/commonMain/kotlin/com/quare/bibleplanner/core/provider/koin/CommonKoinUtils.kt
+++ b/core/provider/koin/src/commonMain/kotlin/com/quare/bibleplanner/core/provider/koin/CommonKoinUtils.kt
@@ -15,6 +15,7 @@ import com.quare.bibleplanner.core.user.di.userModule
 import com.quare.bibleplanner.core.utils.di.utilsModule
 import com.quare.bibleplanner.core.utils.jsonreader.di.jsonReaderModule
 import com.quare.bibleplanner.feature.addnotesfreewarning.di.addNotesFreeWarningModule
+import com.quare.bibleplanner.feature.applanguage.di.appLanguageModule
 import com.quare.bibleplanner.feature.bibleversion.di.bibleVersionModule
 import com.quare.bibleplanner.feature.bookdetails.di.bookDetailsModule
 import com.quare.bibleplanner.feature.books.di.featureBooksModule
@@ -73,6 +74,7 @@ object CommonKoinUtils {
         supabaseModule,
         userModule,
         bibleVersionModule,
+        appLanguageModule,
         modelModule,
         com.quare.bibleplanner.feature.read.di.featureReadModule,
         notificationPermissionModule,

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             implementation(projects.feature.more)
             implementation(projects.feature.books)
             implementation(projects.feature.notificationPermission)
+            implementation(projects.feature.preferences.appLanguage)
 
             // UI
             implementation(projects.ui.component)

--- a/feature/main/src/commonMain/kotlin/com/quare/bibleplanner/feature/main/presentation/screen/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/com/quare/bibleplanner/feature/main/presentation/screen/MainScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation.NavBackStackEntry
 import com.quare.bibleplanner.feature.main.presentation.viewmodel.MainScreenViewModel
 import com.quare.bibleplanner.ui.utils.LocalMainPadding
@@ -17,10 +19,12 @@ fun MainScreen(
     mainScaffoldState: MainScaffoldState,
     bottomNavHost: @Composable () -> Unit,
 ) {
+    val language by mainViewModel.languageState.collectAsState()
     val onEvent = mainViewModel::dispatchUiEvent
     MainScreenContent(
         currentDestination = navBackStackEntry?.destination,
         bottomNavigationModels = mainViewModel.bottomNavigationItemModels,
+        language = language,
         onEvent = onEvent,
         mainScaffoldState = mainScaffoldState,
         content = { paddingValues ->

--- a/feature/main/src/commonMain/kotlin/com/quare/bibleplanner/feature/main/presentation/screen/MainScreenContent.kt
+++ b/feature/main/src/commonMain/kotlin/com/quare/bibleplanner/feature/main/presentation/screen/MainScreenContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -26,6 +27,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import com.quare.bibleplanner.core.model.route.BottomNavRoute
+import com.quare.bibleplanner.core.utils.locale.Language
 import com.quare.bibleplanner.feature.main.presentation.model.BottomNavigationItemModel
 import com.quare.bibleplanner.feature.main.presentation.model.MainScreenUiEvent
 import com.quare.bibleplanner.ui.utils.MainScaffoldState
@@ -36,6 +38,7 @@ import org.jetbrains.compose.resources.stringResource
 fun MainScreenContent(
     currentDestination: NavDestination?,
     bottomNavigationModels: List<BottomNavigationItemModel<Any>>,
+    language: Language,
     onEvent: (MainScreenUiEvent) -> Unit,
     mainScaffoldState: MainScaffoldState,
     content: @Composable (PaddingValues) -> Unit,
@@ -45,6 +48,7 @@ fun MainScreenContent(
             WideMainScreenContent(
                 currentDestination = currentDestination,
                 bottomNavigationModels = bottomNavigationModels,
+                language = language,
                 onEvent = onEvent,
                 mainScaffoldState = mainScaffoldState,
                 content = content,
@@ -53,6 +57,7 @@ fun MainScreenContent(
             NarrowMainScreenContent(
                 currentDestination = currentDestination,
                 bottomNavigationModels = bottomNavigationModels,
+                language = language,
                 onEvent = onEvent,
                 mainScaffoldState = mainScaffoldState,
                 content = content,
@@ -65,23 +70,26 @@ fun MainScreenContent(
 private fun WideMainScreenContent(
     currentDestination: NavDestination?,
     bottomNavigationModels: List<BottomNavigationItemModel<Any>>,
+    language: Language,
     onEvent: (MainScreenUiEvent) -> Unit,
     mainScaffoldState: MainScaffoldState,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     Row(modifier = Modifier.fillMaxSize()) {
         NavigationRail {
-            MainNavigationItems(
-                bottomNavigationModels = bottomNavigationModels,
-                currentDestination = currentDestination,
-                onEvent = onEvent,
-            ) { selected, onClick, icon, label ->
-                NavigationRailItem(
-                    selected = selected,
-                    onClick = onClick,
-                    icon = icon,
-                    label = label,
-                )
+            key(language) {
+                MainNavigationItems(
+                    bottomNavigationModels = bottomNavigationModels,
+                    currentDestination = currentDestination,
+                    onEvent = onEvent,
+                ) { selected, onClick, icon, label ->
+                    NavigationRailItem(
+                        selected = selected,
+                        onClick = onClick,
+                        icon = icon,
+                        label = label,
+                    )
+                }
             }
         }
         Scaffold(
@@ -98,6 +106,7 @@ private fun WideMainScreenContent(
 private fun NarrowMainScreenContent(
     currentDestination: NavDestination?,
     bottomNavigationModels: List<BottomNavigationItemModel<Any>>,
+    language: Language,
     onEvent: (MainScreenUiEvent) -> Unit,
     mainScaffoldState: MainScaffoldState,
     content: @Composable (PaddingValues) -> Unit,
@@ -128,17 +137,19 @@ private fun NarrowMainScreenContent(
                         scrollBehavior.state.heightOffsetLimit = -coordinates.size.height.toFloat()
                     },
             ) {
-                MainNavigationItems(
-                    bottomNavigationModels = bottomNavigationModels,
-                    currentDestination = currentDestination,
-                    onEvent = onEvent,
-                ) { selected, onClick, icon, label ->
-                    NavigationBarItem(
-                        selected = selected,
-                        onClick = onClick,
-                        icon = icon,
-                        label = label,
-                    )
+                key(language) {
+                    MainNavigationItems(
+                        bottomNavigationModels = bottomNavigationModels,
+                        currentDestination = currentDestination,
+                        onEvent = onEvent,
+                    ) { selected, onClick, icon, label ->
+                        NavigationBarItem(
+                            selected = selected,
+                            onClick = onClick,
+                            icon = icon,
+                            label = label,
+                        )
+                    }
                 }
             }
         },

--- a/feature/main/src/commonMain/kotlin/com/quare/bibleplanner/feature/main/presentation/viewmodel/MainScreenViewModel.kt
+++ b/feature/main/src/commonMain/kotlin/com/quare/bibleplanner/feature/main/presentation/viewmodel/MainScreenViewModel.kt
@@ -11,19 +11,32 @@ import bibleplanner.feature.main.generated.resources.books
 import bibleplanner.feature.main.generated.resources.more
 import bibleplanner.feature.main.generated.resources.plans
 import com.quare.bibleplanner.core.model.route.BottomNavRoute
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
 import com.quare.bibleplanner.feature.main.presentation.model.BottomNavigationItemModel
 import com.quare.bibleplanner.feature.main.presentation.model.BottomNavigationItemPresentationModel
 import com.quare.bibleplanner.feature.main.presentation.model.MainScreenUiAction
 import com.quare.bibleplanner.feature.main.presentation.model.MainScreenUiEvent
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-class MainScreenViewModel : ViewModel() {
+class MainScreenViewModel(
+    getAppLanguageFlow: GetAppLanguageFlow,
+) : ViewModel() {
     private val routes: List<BottomNavRoute> = listOf(
         BottomNavRoute.Plans,
         BottomNavRoute.Books,
         BottomNavRoute.More,
+    )
+
+    val languageState: StateFlow<Language> = getAppLanguageFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = Language.ENGLISH,
     )
 
     private val _uiAction: MutableSharedFlow<MainScreenUiAction> = MutableSharedFlow()

--- a/feature/more/build.gradle.kts
+++ b/feature/more/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
             implementation(libs.androidx.room.runtime)
 
             // Features
+            implementation(projects.feature.preferences.appLanguage)
             implementation(projects.feature.preferences.themeSelection)
             implementation(projects.feature.materialYou)
             implementation(projects.feature.subscriptionDetails)

--- a/feature/more/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/more/src/commonMain/composeResources/values-es/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="more">Más</string>
     <string name="theme_option">Tema</string>
+    <string name="app_language_option">Idioma</string>
     <string name="bible_version_option">Versión de la Biblia</string>
     <string name="terms_of_service">Términos de Servicio</string>
     <string name="privacy_policy">Política de Privacidad</string>

--- a/feature/more/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/feature/more/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="more">Mais</string>
     <string name="theme_option">Tema</string>
+    <string name="app_language_option">Idioma</string>
     <string name="bible_version_option">Versão da Bíblia</string>
     <string name="terms_of_service">Termos de Serviço</string>
     <string name="privacy_policy">Política de Privacidade</string>

--- a/feature/more/src/commonMain/composeResources/values/strings.xml
+++ b/feature/more/src/commonMain/composeResources/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="more">More</string>
     <string name="theme_option">Theme</string>
+    <string name="app_language_option">Language</string>
     <string name="bible_version_option">Bible version</string>
     <string name="terms_of_service">Terms of Service</string>
     <string name="privacy_policy">Privacy Policy</string>

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/MoreScreen.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/MoreScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -38,33 +39,35 @@ internal fun MoreScreen(
         }
 
         is MoreUiState.Loaded -> {
-            if (state.showSubscriptionDetailsDialog) {
-                SubscriptionDetailsDialog(
-                    onDismiss = { onEvent(MoreUiEvent.OnDismissSubscriptionDetailsDialog) },
+            key(state.selectedLanguage) {
+                if (state.showSubscriptionDetailsDialog) {
+                    SubscriptionDetailsDialog(
+                        onDismiss = { onEvent(MoreUiEvent.OnDismissSubscriptionDetailsDialog) },
+                    )
+                }
+                ResponsiveColumn(
+                    modifier = Modifier.padding(16.dp),
+                    contentPadding = mainPadding,
+                    portraitContent = {
+                        moreScreenPortraitLayout(
+                            state = state,
+                            onEvent = onEvent,
+                            becomeProTitleContent = becomeProTitleContent,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedContentScope = animatedContentScope,
+                        )
+                    },
+                    landscapeContent = {
+                        moreScreenLandscapeLayout(
+                            state = state,
+                            onEvent = onEvent,
+                            becomeProTitleContent = becomeProTitleContent,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedContentScope = animatedContentScope,
+                        )
+                    },
                 )
             }
-            ResponsiveColumn(
-                modifier = Modifier.padding(16.dp),
-                contentPadding = mainPadding,
-                portraitContent = {
-                    moreScreenPortraitLayout(
-                        state = state,
-                        onEvent = onEvent,
-                        becomeProTitleContent = becomeProTitleContent,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedContentScope = animatedContentScope,
-                    )
-                },
-                landscapeContent = {
-                    moreScreenLandscapeLayout(
-                        state = state,
-                        onEvent = onEvent,
-                        becomeProTitleContent = becomeProTitleContent,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedContentScope = animatedContentScope,
-                    )
-                },
-            )
         }
     }
 }

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/content/component/PreferencesSection.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/content/component/PreferencesSection.kt
@@ -10,12 +10,18 @@ import androidx.compose.ui.unit.dp
 import bibleplanner.feature.more.generated.resources.Res
 import bibleplanner.feature.more.generated.resources.preferences
 import bibleplanner.feature.more.generated.resources.today
+import bibleplanner.feature.preferences.app_language.generated.resources.language_english
+import bibleplanner.feature.preferences.app_language.generated.resources.language_portuguese_brazil
+import bibleplanner.feature.preferences.app_language.generated.resources.language_spanish
+import com.quare.bibleplanner.core.utils.locale.Language
 import com.quare.bibleplanner.feature.more.presentation.factory.MoreMenuOptionsFactory
 import com.quare.bibleplanner.feature.more.presentation.model.MoreOptionItemType
 import com.quare.bibleplanner.feature.more.presentation.model.MoreUiEvent
 import com.quare.bibleplanner.feature.more.presentation.model.MoreUiState
 import com.quare.bibleplanner.ui.utils.toStringResource
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import bibleplanner.feature.preferences.app_language.generated.resources.Res as AppLanguageRes
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -39,6 +45,12 @@ internal fun PreferencesSection(
             )
             HorizontalDivider()
             MoreMenuItem(
+                itemModel = MoreMenuOptionsFactory.appLanguage,
+                subtitle = stringResource(state.selectedLanguage.toStringResource()),
+                onClick = { onEvent(MoreUiEvent.OnItemClick(MoreOptionItemType.APP_LANGUAGE)) },
+            )
+            HorizontalDivider()
+            MoreMenuItem(
                 itemModel = MoreMenuOptionsFactory.bibleVersion,
                 subtitle = state.bibleVersionName?.let { safeBibleVersionName ->
                     if (state.bibleDownloadProgress != null) {
@@ -57,6 +69,12 @@ internal fun PreferencesSection(
             )
         }
     }
+}
+
+private fun Language.toStringResource(): StringResource = when (this) {
+    Language.ENGLISH -> AppLanguageRes.string.language_english
+    Language.PORTUGUESE_BRAZIL -> AppLanguageRes.string.language_portuguese_brazil
+    Language.SPANISH -> AppLanguageRes.string.language_spanish
 }
 
 @Composable

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/factory/MoreMenuOptionsFactory.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/factory/MoreMenuOptionsFactory.kt
@@ -8,7 +8,9 @@ import androidx.compose.material.icons.filled.EditCalendar
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Translate
 import bibleplanner.feature.more.generated.resources.Res
+import bibleplanner.feature.more.generated.resources.app_language_option
 import bibleplanner.feature.more.generated.resources.become_pro
 import bibleplanner.feature.more.generated.resources.bible_version_option
 import bibleplanner.feature.more.generated.resources.delete_progress_option
@@ -34,6 +36,11 @@ internal object MoreMenuOptionsFactory {
         name = Res.string.theme_option,
         icon = MoreIcon.ImageVectorIcon(Icons.Default.Palette),
         type = MoreOptionItemType.THEME,
+    )
+    val appLanguage = MoreMenuItemPresentationModel(
+        name = Res.string.app_language_option,
+        icon = MoreIcon.ImageVectorIcon(Icons.Default.Translate),
+        type = MoreOptionItemType.APP_LANGUAGE,
     )
     val instagram = MoreMenuItemPresentationModel(
         name = Res.string.instagram,

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/factory/MoreUiStateFactory.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/factory/MoreUiStateFactory.kt
@@ -23,6 +23,7 @@ import com.quare.bibleplanner.core.provider.room.entity.BibleVersionEntity
 import com.quare.bibleplanner.core.remoteconfig.domain.usecase.login.IsLoginVisible
 import com.quare.bibleplanner.core.remoteconfig.domain.usecase.web.IsMoreWebAppEnabled
 import com.quare.bibleplanner.core.user.data.mapper.SessionUserMapper
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
 import com.quare.bibleplanner.feature.materialyou.domain.usecase.GetIsDynamicColorsEnabledFlow
 import com.quare.bibleplanner.feature.materialyou.domain.usecase.IsDynamicColorSupported
 import com.quare.bibleplanner.feature.more.domain.model.AccountStatusModel
@@ -65,6 +66,7 @@ internal class MoreUiStateFactory(
     private val bibleVersionDao: BibleVersionDao,
     private val getSelectedVersionDownloadedChapters: GetSelectedVersionDownloadedChaptersFlowUseCase,
     private val getSelectedBible: GetSelectedBibleFlowUseCase,
+    private val getAppLanguageFlow: GetAppLanguageFlow,
 ) {
     fun create(): Flow<MoreUiState> {
         val moreScreenFlows: Flow<MoreScreenConfiguration> = combine(
@@ -88,7 +90,8 @@ internal class MoreUiStateFactory(
             getPlanStartDate(),
             moreScreenFlows,
             getSelectedVersionDownloadedChapters(),
-        ) { subscriptionStatus, startDate, moreScreenConfiguration, downloadedChaptersCount ->
+            getAppLanguageFlow(),
+        ) { subscriptionStatus, startDate, moreScreenConfiguration, downloadedChaptersCount, selectedLanguage ->
             val remoteConfigs = moreScreenConfiguration.remoteConfigs
             val themeConfiguration = moreScreenConfiguration.themeConfiguration
             val shouldShowDonate = remoteConfigs.shouldShowDonate
@@ -147,6 +150,7 @@ internal class MoreUiStateFactory(
                 isLoginVisible = remoteConfigs.isLoginVisible,
                 bibleVersionName = selectedBible?.version?.name,
                 bibleDownloadProgress = downloadProgress,
+                selectedLanguage = selectedLanguage,
             )
         }
     }

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/model/MoreOptionItemType.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/model/MoreOptionItemType.kt
@@ -3,6 +3,7 @@ package com.quare.bibleplanner.feature.more.presentation.model
 enum class MoreOptionItemType {
     BECOME_PRO,
     THEME,
+    APP_LANGUAGE,
     INSTAGRAM,
     PRIVACY_POLICY,
     TERMS,

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/model/MoreUiState.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/model/MoreUiState.kt
@@ -1,6 +1,7 @@
 package com.quare.bibleplanner.feature.more.presentation.model
 
 import com.quare.bibleplanner.core.provider.billing.domain.model.SubscriptionStatus
+import com.quare.bibleplanner.core.utils.locale.Language
 import com.quare.bibleplanner.feature.more.domain.model.AccountStatusModel
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.StringResource
@@ -25,5 +26,6 @@ internal sealed interface MoreUiState {
         val accountStatusModel: AccountStatusModel,
         val bibleVersionName: String?,
         val bibleDownloadProgress: Float?,
+        val selectedLanguage: Language,
     ) : MoreUiState
 }

--- a/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/viewmodel/MoreViewModel.kt
+++ b/feature/more/src/commonMain/kotlin/com/quare/bibleplanner/feature/more/presentation/viewmodel/MoreViewModel.kt
@@ -3,6 +3,7 @@ package com.quare.bibleplanner.feature.more.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.quare.bibleplanner.core.books.domain.usecase.CalculateBibleProgressUseCase
+import com.quare.bibleplanner.core.model.route.AppLanguageNavRoute
 import com.quare.bibleplanner.core.model.route.BibleVersionSelectorRoute
 import com.quare.bibleplanner.core.model.route.DeleteAllProgressNavRoute
 import com.quare.bibleplanner.core.model.route.DonationNavRoute
@@ -50,6 +51,10 @@ internal class MoreViewModel(
                 when (event.type) {
                     MoreOptionItemType.THEME -> {
                         goToRoute(ThemeNavRoute)
+                    }
+
+                    MoreOptionItemType.APP_LANGUAGE -> {
+                        goToRoute(AppLanguageNavRoute)
                     }
 
                     MoreOptionItemType.PRIVACY_POLICY -> {

--- a/feature/preferences/app_language/build.gradle.kts
+++ b/feature/preferences/app_language/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    alias(libs.plugins.bibleplanner.kotlinMultiplatform)
+    alias(libs.plugins.bibleplanner.composeMultiplatform)
+}
+
+kotlin {
+    androidLibrary {
+        namespace = "com.quare.bibleplanner.feature.applanguage"
+    }
+
+    jvm()
+
+    sourceSets {
+        commonMain.dependencies {
+            // Core
+            implementation(projects.core.provider.platform)
+            implementation(projects.core.model)
+            implementation(projects.core.utils)
+
+            // UI
+            implementation(projects.ui.component)
+            implementation(projects.ui.utils)
+
+            // Compose
+            implementation(libs.runtime)
+            implementation(libs.foundation)
+            implementation(libs.material3)
+            implementation(libs.ui)
+            implementation(libs.material.icons.extended)
+            implementation(libs.components.resources)
+
+            // Navigation
+            implementation(libs.compose.navigation)
+
+            // Koin
+            implementation(project.dependencies.platform(libs.koinBom))
+            implementation(libs.koinCore)
+            implementation(libs.koinCompose)
+            implementation(libs.koinComposeViewModel)
+
+            // Data Store
+            implementation(libs.dataStore)
+            implementation(libs.dataStore.preferences)
+        }
+    }
+}
+
+compose.resources {
+    publicResClass = true
+}

--- a/feature/preferences/app_language/src/androidMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/AndroidAppLanguageModule.kt
+++ b/feature/preferences/app_language/src/androidMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/AndroidAppLanguageModule.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.applanguage.di
+
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import com.quare.bibleplanner.feature.applanguage.presentation.AndroidApplyLocale
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val androidAppLanguageModule = module {
+    factoryOf(::AndroidApplyLocale).bind<ApplyLocale>()
+}

--- a/feature/preferences/app_language/src/androidMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AndroidApplyLocale.kt
+++ b/feature/preferences/app_language/src/androidMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AndroidApplyLocale.kt
@@ -1,0 +1,8 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+
+internal class AndroidApplyLocale : ApplyLocale {
+    override fun invoke(language: Language) = Unit
+}

--- a/feature/preferences/app_language/src/androidMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.android.kt
+++ b/feature/preferences/app_language/src/androidMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.android.kt
@@ -1,0 +1,43 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.utils
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.edit
+import com.quare.bibleplanner.core.utils.locale.Language
+
+@Composable
+actual fun rememberApplyLanguage(): (Language) -> Unit {
+    val context = LocalContext.current
+    return remember(context) {
+        { language ->
+            context
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit {
+                    putString(KEY_APP_LANGUAGE, language.toLocaleTag())
+                }
+            context.findActivity()?.recreate()
+        }
+    }
+}
+
+private fun Context.findActivity(): ComponentActivity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is ComponentActivity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+private fun Language.toLocaleTag(): String = when (this) {
+    Language.ENGLISH -> "en"
+    Language.PORTUGUESE_BRAZIL -> "pt-BR"
+    Language.SPANISH -> "es"
+}
+
+internal const val PREFS_NAME = "app_prefs"
+internal const val KEY_APP_LANGUAGE = "app_language"

--- a/feature/preferences/app_language/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/preferences/app_language/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_language_title">Idioma de la Aplicación</string>
+    <string name="language_english">English</string>
+    <string name="language_portuguese_brazil">Portugués (Brasil)</string>
+    <string name="language_spanish">Español</string>
+</resources>

--- a/feature/preferences/app_language/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/feature/preferences/app_language/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_language_title">Idioma do Aplicativo</string>
+    <string name="language_english">English</string>
+    <string name="language_portuguese_brazil">Português (Brasil)</string>
+    <string name="language_spanish">Espanhol</string>
+</resources>

--- a/feature/preferences/app_language/src/commonMain/composeResources/values/strings.xml
+++ b/feature/preferences/app_language/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_language_title">App Language</string>
+    <string name="language_english">English</string>
+    <string name="language_portuguese_brazil">Portuguese (Brazil)</string>
+    <string name="language_spanish">Spanish</string>
+</resources>

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/data/mapper/AppLanguageMapper.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/data/mapper/AppLanguageMapper.kt
@@ -1,0 +1,9 @@
+package com.quare.bibleplanner.feature.applanguage.data.mapper
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+interface AppLanguageMapper {
+    fun mapPreferenceToModel(preference: String?): Language
+
+    fun mapModelToPreference(language: Language): String
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/data/mapper/AppLanguageMapperImpl.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/data/mapper/AppLanguageMapperImpl.kt
@@ -1,0 +1,23 @@
+package com.quare.bibleplanner.feature.applanguage.data.mapper
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+internal class AppLanguageMapperImpl : AppLanguageMapper {
+    override fun mapPreferenceToModel(preference: String?): Language = when (preference) {
+        PORTUGUESE_BRAZIL -> Language.PORTUGUESE_BRAZIL
+        SPANISH -> Language.SPANISH
+        else -> Language.ENGLISH
+    }
+
+    override fun mapModelToPreference(language: Language): String = when (language) {
+        Language.ENGLISH -> ENGLISH
+        Language.PORTUGUESE_BRAZIL -> PORTUGUESE_BRAZIL
+        Language.SPANISH -> SPANISH
+    }
+
+    companion object {
+        private const val ENGLISH = "en"
+        private const val PORTUGUESE_BRAZIL = "pt-BR"
+        private const val SPANISH = "es"
+    }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/data/repository/AppLanguageRepositoryImpl.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/data/repository/AppLanguageRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.quare.bibleplanner.feature.applanguage.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.data.mapper.AppLanguageMapper
+import com.quare.bibleplanner.feature.applanguage.domain.repository.AppLanguageRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+internal class AppLanguageRepositoryImpl(
+    private val dataStore: DataStore<Preferences>,
+    private val mapper: AppLanguageMapper,
+) : AppLanguageRepository {
+    override fun getLanguageFlow(): Flow<Language> = dataStore.data.map { preferences ->
+        mapper.mapPreferenceToModel(preferences[stringPreferencesKey(APP_LANGUAGE)])
+    }
+
+    override suspend fun setLanguage(language: Language) {
+        dataStore.edit {
+            it[stringPreferencesKey(APP_LANGUAGE)] = mapper.mapModelToPreference(language)
+        }
+    }
+
+    companion object {
+        private const val APP_LANGUAGE = "app_language"
+    }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/AppLanguageModule.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/AppLanguageModule.kt
@@ -1,0 +1,33 @@
+package com.quare.bibleplanner.feature.applanguage.di
+
+import com.quare.bibleplanner.feature.applanguage.data.mapper.AppLanguageMapper
+import com.quare.bibleplanner.feature.applanguage.data.mapper.AppLanguageMapperImpl
+import com.quare.bibleplanner.feature.applanguage.data.repository.AppLanguageRepositoryImpl
+import com.quare.bibleplanner.feature.applanguage.domain.repository.AppLanguageRepository
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.ObserveAppLocale
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.SetAppLanguage
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.impl.GetAppLanguageFlowUseCase
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.impl.ObserveAppLocaleUseCase
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.impl.SetAppLanguageUseCase
+import com.quare.bibleplanner.feature.applanguage.presentation.AppLanguageViewModel
+import com.quare.bibleplanner.feature.applanguage.presentation.factory.AppLanguageUiStateFactory
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val appLanguageModule = module {
+    // Data
+    factoryOf(::AppLanguageRepositoryImpl).bind<AppLanguageRepository>()
+    factoryOf(::AppLanguageMapperImpl).bind<AppLanguageMapper>()
+
+    // Domain
+    factoryOf(::GetAppLanguageFlowUseCase).bind<GetAppLanguageFlow>()
+    factoryOf(::SetAppLanguageUseCase).bind<SetAppLanguage>()
+    factoryOf(::ObserveAppLocaleUseCase).bind<ObserveAppLocale>()
+
+    // Presentation
+    factoryOf(::AppLanguageUiStateFactory)
+    viewModelOf(::AppLanguageViewModel)
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/ApplyLocale.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/ApplyLocale.kt
@@ -1,0 +1,7 @@
+package com.quare.bibleplanner.feature.applanguage.domain
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+fun interface ApplyLocale {
+    operator fun invoke(language: Language)
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/repository/AppLanguageRepository.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/repository/AppLanguageRepository.kt
@@ -1,0 +1,10 @@
+package com.quare.bibleplanner.feature.applanguage.domain.repository
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import kotlinx.coroutines.flow.Flow
+
+interface AppLanguageRepository {
+    fun getLanguageFlow(): Flow<Language>
+
+    suspend fun setLanguage(language: Language)
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/GetAppLanguageFlow.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/GetAppLanguageFlow.kt
@@ -1,0 +1,8 @@
+package com.quare.bibleplanner.feature.applanguage.domain.usecase
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import kotlinx.coroutines.flow.Flow
+
+fun interface GetAppLanguageFlow {
+    operator fun invoke(): Flow<Language>
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/ObserveAppLocale.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/ObserveAppLocale.kt
@@ -1,0 +1,5 @@
+package com.quare.bibleplanner.feature.applanguage.domain.usecase
+
+fun interface ObserveAppLocale {
+    suspend operator fun invoke()
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/SetAppLanguage.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/SetAppLanguage.kt
@@ -1,0 +1,7 @@
+package com.quare.bibleplanner.feature.applanguage.domain.usecase
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+interface SetAppLanguage {
+    suspend operator fun invoke(language: Language)
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/impl/GetAppLanguageFlowUseCase.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/impl/GetAppLanguageFlowUseCase.kt
@@ -1,0 +1,12 @@
+package com.quare.bibleplanner.feature.applanguage.domain.usecase.impl
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.repository.AppLanguageRepository
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
+import kotlinx.coroutines.flow.Flow
+
+internal class GetAppLanguageFlowUseCase(
+    private val repository: AppLanguageRepository,
+) : GetAppLanguageFlow {
+    override fun invoke(): Flow<Language> = repository.getLanguageFlow()
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/impl/ObserveAppLocaleUseCase.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/impl/ObserveAppLocaleUseCase.kt
@@ -1,0 +1,16 @@
+package com.quare.bibleplanner.feature.applanguage.domain.usecase.impl
+
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.ObserveAppLocale
+
+internal class ObserveAppLocaleUseCase(
+    private val getAppLanguageFlow: GetAppLanguageFlow,
+    private val applyLocale: ApplyLocale,
+) : ObserveAppLocale {
+    override suspend fun invoke() {
+        getAppLanguageFlow().collect { language ->
+            applyLocale(language)
+        }
+    }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/impl/SetAppLanguageUseCase.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/domain/usecase/impl/SetAppLanguageUseCase.kt
@@ -1,0 +1,13 @@
+package com.quare.bibleplanner.feature.applanguage.domain.usecase.impl
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.repository.AppLanguageRepository
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.SetAppLanguage
+
+internal class SetAppLanguageUseCase(
+    private val repository: AppLanguageRepository,
+) : SetAppLanguage {
+    override suspend fun invoke(language: Language) {
+        repository.setLanguage(language)
+    }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AppLanguageContent.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AppLanguageContent.kt
@@ -1,0 +1,56 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import bibleplanner.feature.preferences.app_language.generated.resources.Res
+import bibleplanner.feature.preferences.app_language.generated.resources.app_language_title
+import bibleplanner.feature.preferences.app_language.generated.resources.language_english
+import bibleplanner.feature.preferences.app_language.generated.resources.language_portuguese_brazil
+import bibleplanner.feature.preferences.app_language.generated.resources.language_spanish
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.presentation.component.AppLanguageItem
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiEvent
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiState
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun AppLanguageContent(
+    uiState: AppLanguageUiState,
+    onEvent: (AppLanguageUiEvent) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding(),
+    ) {
+        Text(
+            text = stringResource(Res.string.app_language_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        )
+        val languages = Language.entries
+        languages.forEachIndexed { index, language ->
+            AppLanguageItem(
+                name = stringResource(language.toStringResource()),
+                isSelected = language == uiState.selectedLanguage,
+                onClick = { onEvent(AppLanguageUiEvent.OnLanguageSelected(language)) },
+            )
+            if (index < languages.lastIndex) HorizontalDivider()
+        }
+    }
+}
+
+private fun Language.toStringResource(): StringResource = when (this) {
+    Language.ENGLISH -> Res.string.language_english
+    Language.PORTUGUESE_BRAZIL -> Res.string.language_portuguese_brazil
+    Language.SPANISH -> Res.string.language_spanish
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AppLanguageRoot.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AppLanguageRoot.kt
@@ -1,0 +1,32 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.dialog
+import com.quare.bibleplanner.core.model.route.AppLanguageNavRoute
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiEvent
+import com.quare.bibleplanner.feature.applanguage.presentation.utils.AppLanguageActionCollector
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+fun NavGraphBuilder.appLanguage(navController: NavHostController) {
+    dialog<AppLanguageNavRoute> {
+        val viewModel = koinViewModel<AppLanguageViewModel>()
+        val uiState by viewModel.uiState.collectAsState()
+        AppLanguageActionCollector(
+            actionsFlow = viewModel.uiAction,
+            navController = navController,
+        )
+        val onEvent = viewModel::onEvent
+        ModalBottomSheet(onDismissRequest = { onEvent(AppLanguageUiEvent.OnDismiss) }) {
+            AppLanguageContent(
+                uiState = uiState,
+                onEvent = onEvent,
+            )
+        }
+    }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AppLanguageViewModel.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/AppLanguageViewModel.kt
@@ -1,0 +1,50 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.SetAppLanguage
+import com.quare.bibleplanner.feature.applanguage.presentation.factory.AppLanguageUiStateFactory
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiAction
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiEvent
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiState
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+internal class AppLanguageViewModel(
+    private val setAppLanguage: SetAppLanguage,
+    factory: AppLanguageUiStateFactory,
+) : ViewModel() {
+    private val _uiAction: MutableSharedFlow<AppLanguageUiAction> = MutableSharedFlow()
+    val uiAction: SharedFlow<AppLanguageUiAction> = _uiAction
+
+    val uiState: StateFlow<AppLanguageUiState> = factory.create().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = AppLanguageUiState(Language.ENGLISH),
+    )
+
+    fun onEvent(event: AppLanguageUiEvent) {
+        when (event) {
+            is AppLanguageUiEvent.OnLanguageSelected -> selectLanguage(event.language)
+            AppLanguageUiEvent.OnDismiss -> emitAction(AppLanguageUiAction.NavigateUp)
+        }
+    }
+
+    private fun selectLanguage(language: Language) {
+        viewModelScope.launch {
+            setAppLanguage(language)
+            emitAction(AppLanguageUiAction.ApplyAndNavigateUp(language))
+        }
+    }
+
+    private fun emitAction(action: AppLanguageUiAction) {
+        viewModelScope.launch {
+            _uiAction.emit(action)
+        }
+    }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/InitAppLocale.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/InitAppLocale.kt
@@ -1,0 +1,13 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
+import kotlinx.coroutines.flow.first
+
+suspend fun initAppLocale(
+    getAppLanguageFlow: GetAppLanguageFlow,
+    applyLocale: ApplyLocale,
+) {
+    val language = getAppLanguageFlow().first()
+    applyLocale(language)
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/component/AppLanguageItem.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/component/AppLanguageItem.kt
@@ -1,0 +1,27 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal fun AppLanguageItem(
+    name: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ListItem(
+        headlineContent = { Text(name) },
+        trailingContent = {
+            RadioButton(
+                selected = isSelected,
+                onClick = onClick,
+            )
+        },
+        modifier = modifier.clickable(onClick = onClick),
+    )
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/factory/AppLanguageUiStateFactory.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/factory/AppLanguageUiStateFactory.kt
@@ -1,0 +1,12 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.factory
+
+import com.quare.bibleplanner.feature.applanguage.domain.usecase.GetAppLanguageFlow
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+internal class AppLanguageUiStateFactory(
+    private val getAppLanguageFlow: GetAppLanguageFlow,
+) {
+    fun create(): Flow<AppLanguageUiState> = getAppLanguageFlow().map { AppLanguageUiState(it) }
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/model/AppLanguageUiAction.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/model/AppLanguageUiAction.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.model
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+internal sealed interface AppLanguageUiAction {
+    data object NavigateUp : AppLanguageUiAction
+
+    data class ApplyAndNavigateUp(
+        val language: Language,
+    ) : AppLanguageUiAction
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/model/AppLanguageUiEvent.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/model/AppLanguageUiEvent.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.model
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+internal sealed interface AppLanguageUiEvent {
+    data class OnLanguageSelected(
+        val language: Language,
+    ) : AppLanguageUiEvent
+
+    data object OnDismiss : AppLanguageUiEvent
+}

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/model/AppLanguageUiState.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/model/AppLanguageUiState.kt
@@ -1,0 +1,7 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.model
+
+import com.quare.bibleplanner.core.utils.locale.Language
+
+internal data class AppLanguageUiState(
+    val selectedLanguage: Language,
+)

--- a/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.kt
+++ b/feature/preferences/app_language/src/commonMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.kt
@@ -1,0 +1,31 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.presentation.model.AppLanguageUiAction
+import com.quare.bibleplanner.ui.utils.ActionCollector
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+internal fun AppLanguageActionCollector(
+    actionsFlow: Flow<AppLanguageUiAction>,
+    navController: NavHostController,
+) {
+    val applyLanguage = rememberApplyLanguage()
+    ActionCollector(actionsFlow) { action ->
+        when (action) {
+            AppLanguageUiAction.NavigateUp -> {
+                navController.navigateUp()
+            }
+
+            is AppLanguageUiAction.ApplyAndNavigateUp -> {
+                applyLanguage(action.language)
+                navController.navigateUp()
+            }
+        }
+    }
+}
+
+@Composable
+expect fun rememberApplyLanguage(): (Language) -> Unit

--- a/feature/preferences/app_language/src/iosMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/IosAppLanguageModule.kt
+++ b/feature/preferences/app_language/src/iosMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/IosAppLanguageModule.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.applanguage.di
+
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import com.quare.bibleplanner.feature.applanguage.presentation.IosApplyLocale
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val iosAppLanguageModule = module {
+    factoryOf(::IosApplyLocale).bind<ApplyLocale>()
+}

--- a/feature/preferences/app_language/src/iosMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/IosApplyLocale.kt
+++ b/feature/preferences/app_language/src/iosMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/IosApplyLocale.kt
@@ -1,0 +1,21 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import platform.Foundation.NSUserDefaults
+
+internal class IosApplyLocale : ApplyLocale {
+    override fun invoke(language: Language) {
+        NSUserDefaults.standardUserDefaults.setObject(
+            listOf(language.toLocaleTag()),
+            forKey = "AppleLanguages",
+        )
+        NSUserDefaults.standardUserDefaults.synchronize()
+    }
+
+    private fun Language.toLocaleTag(): String = when (this) {
+        Language.ENGLISH -> "en"
+        Language.PORTUGUESE_BRAZIL -> "pt-BR"
+        Language.SPANISH -> "es"
+    }
+}

--- a/feature/preferences/app_language/src/iosMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.ios.kt
+++ b/feature/preferences/app_language/src/iosMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.ios.kt
@@ -1,0 +1,7 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.utils
+
+import androidx.compose.runtime.Composable
+import com.quare.bibleplanner.core.utils.locale.Language
+
+@Composable
+actual fun rememberApplyLanguage(): (Language) -> Unit = { }

--- a/feature/preferences/app_language/src/jvmMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/JvmAppLanguageModule.kt
+++ b/feature/preferences/app_language/src/jvmMain/kotlin/com/quare/bibleplanner/feature/applanguage/di/JvmAppLanguageModule.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.applanguage.di
+
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import com.quare.bibleplanner.feature.applanguage.presentation.JvmApplyLocale
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+val jvmAppLanguageModule = module {
+    factoryOf(::JvmApplyLocale).bind<ApplyLocale>()
+}

--- a/feature/preferences/app_language/src/jvmMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/JvmApplyLocale.kt
+++ b/feature/preferences/app_language/src/jvmMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/JvmApplyLocale.kt
@@ -1,0 +1,17 @@
+package com.quare.bibleplanner.feature.applanguage.presentation
+
+import com.quare.bibleplanner.core.utils.locale.Language
+import com.quare.bibleplanner.feature.applanguage.domain.ApplyLocale
+import java.util.Locale
+
+internal class JvmApplyLocale : ApplyLocale {
+    override fun invoke(language: Language) {
+        Locale.setDefault(Locale.forLanguageTag(language.toLocaleTag()))
+    }
+
+    private fun Language.toLocaleTag(): String = when (this) {
+        Language.ENGLISH -> "en"
+        Language.PORTUGUESE_BRAZIL -> "pt-BR"
+        Language.SPANISH -> "es"
+    }
+}

--- a/feature/preferences/app_language/src/jvmMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.jvm.kt
+++ b/feature/preferences/app_language/src/jvmMain/kotlin/com/quare/bibleplanner/feature/applanguage/presentation/utils/AppLanguageActionCollector.jvm.kt
@@ -1,0 +1,7 @@
+package com.quare.bibleplanner.feature.applanguage.presentation.utils
+
+import androidx.compose.runtime.Composable
+import com.quare.bibleplanner.core.utils.locale.Language
+
+@Composable
+actual fun rememberApplyLanguage(): (Language) -> Unit = { }

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
@@ -1,6 +1,7 @@
 {
   "1.13.0": [
-    "Fix extra whitespace below the search bar on the books screen."
+    "Fix extra whitespace below the search bar on the books screen.",
+    "You can now change the app language from the 'More' screen. English, Portuguese (Brazil), and Spanish are available."
   ],
   "1.12.0": [
     "Notifications about the download progress of Bible versions."

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
@@ -1,6 +1,7 @@
 {
   "1.13.0": [
-    "Corrección del espacio en blanco extra debajo de la barra de búsqueda en la pantalla de libros."
+    "Corrección del espacio en blanco extra debajo de la barra de búsqueda en la pantalla de libros.",
+    "Ahora puedes cambiar el idioma de la aplicación desde la pantalla 'Más'. Están disponibles inglés, portugués (Brasil) y español."
   ],
   "1.12.0": [
     "Notificaciones sobre el progreso de la descarga de las versiones de la Biblia."

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
@@ -1,6 +1,7 @@
 {
   "1.13.0": [
-    "Correção do espaço em branco extra abaixo da barra de pesquisa na tela de livros."
+    "Correção do espaço em branco extra abaixo da barra de pesquisa na tela de livros.",
+    "Agora é possível alterar o idioma do aplicativo pela tela 'Mais'. Inglês, Português (Brasil) e Espanhol estão disponíveis."
   ],
   "1.12.0": [
     "Notificações sobre progresso de download de versões da biblia."

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,6 +61,7 @@ include(":feature:add_notes_free_warning")
 include(":feature:preferences:edit_plan_start_date")
 include(":feature:login")
 include(":feature:preferences:bible_version")
+include(":feature:preferences:app_language")
 include(":feature:read")
 
 include(":feature:paywall")


### PR DESCRIPTION
## Summary

- Adds a new **Language** option in the "More" screen (Preferences section), allowing users to switch the app language without leaving the app
- Supports English, Portuguese (Brazil), and Spanish — selection is persisted via DataStore and survives app restarts
- A new `feature/preferences/app_language` module handles all language logic (data, domain, presentation) with platform-specific locale application (Android recreates the activity; iOS updates `NSUserDefaults`; Desktop sets `Locale.setDefault` before first composition)
- The bottom navigation bar and all strings on the "More" screen update immediately on language change across all platforms

## Test plan

- [ ] Open the app → "More" screen shows a "Language" item in the Preferences section
- [ ] Tap Language → bottom sheet opens with 3 options; current language is highlighted
- [ ] Select a different language → bottom sheet closes and all strings on the "More" screen (section headers, menu items) update immediately
- [ ] Bottom navigation bar labels also update immediately
- [ ] Force-kill and reopen the app → selected language persists
- [ ] Verify on Android, iOS, and Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)