### PR TITLE
chore: add release CI/CD pipeline for Play Store and App Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: release
+
+# Release pipeline — builds and ships Bible Planner to the stores.
+#
+# Triggers:
+#   - Manually from the Actions tab (workflow_dispatch), choosing platform/track.
+#   - Pushing a version tag (e.g. v1.14.0).
+#
+# Secrets are exposed only to the `production` environment. Configure
+# required reviewers on that environment (Settings > Environments) so each
+# release needs manual approval — this keeps the public repo safe.
+#
+# Reminder: bump versionCode/versionName (gradle.properties) and
+# CURRENT_PROJECT_VERSION/MARKETING_VERSION (Config.xcconfig) before releasing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platforms to release"
+        type: choice
+        options:
+          - both
+          - android
+          - ios
+        default: both
+      track:
+        description: "Android Play Store track"
+        type: choice
+        options:
+          - production
+          - beta
+          - alpha
+          - internal
+        default: production
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  android:
+    name: Android — Google Play
+    if: ${{ github.event_name == 'push' || github.event.inputs.platforms == 'both' || github.event.inputs.platforms == 'android' }}
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Gradle and Java
+        uses: ./.github/actions/gradle
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --no-document
+
+      - name: Decode signing and config secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
+          echo "$GOOGLE_SERVICES_JSON" | base64 --decode > androidApp/google-services.json
+          printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-service-account.json"
+
+      - name: Build and upload to Google Play
+        run: fastlane android release track:"${{ github.event.inputs.track || 'production' }}"
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          PLAY_STORE_JSON_KEY_PATH: ${{ runner.temp }}/play-service-account.json
+
+  ios:
+    name: iOS — App Store Connect
+    if: ${{ github.event_name == 'push' || github.event.inputs.platforms == 'both' || github.event.inputs.platforms == 'ios' }}
+    runs-on: macos-latest
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Gradle and Java
+        uses: ./.github/actions/gradle
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --no-document
+
+      - name: Prepare SSH access to the certificates repo
+        env:
+          MATCH_SSH_PRIVATE_KEY: ${{ secrets.MATCH_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$MATCH_SSH_PRIVATE_KEY" > "$RUNNER_TEMP/match_ci_ssh"
+          chmod 600 "$RUNNER_TEMP/match_ci_ssh"
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
+
+      - name: Decode Firebase config
+        env:
+          GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
+        run: echo "$GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > iosApp/iosApp/GoogleService-Info.plist
+
+      - name: Build and upload to App Store Connect
+        run: fastlane ios release
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/match_ci_ssh -o IdentitiesOnly=yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,27 @@
 name: release
 
-# Release pipeline — builds and ships Bible Planner to the stores.
+# Release pipeline — versions, builds and ships Bible Planner to the stores.
 #
-# Triggers:
-#   - Manually from the Actions tab (workflow_dispatch), choosing platform/track.
-#   - Pushing a version tag (e.g. v1.14.0).
+# Run it manually from the Actions tab:
+#   1. `plan` resolves the version — auto-inferred from the commits since the
+#      last release, or taken from the optional `version` input — and shows it
+#      in the run summary.
+#   2. The run pauses on the `Production` environment. Review the planned
+#      version in the summary, then approve to continue (or reject and start a
+#      new run with the `version` input to override).
+#   3. Android and iOS are built and uploaded to the stores.
+#   4. `finalize` bumps the version on a release branch, opens and squash-merges
+#      the merge-back PR into main, and publishes the GitHub release.
 #
-# Secrets are exposed only to the `Production` environment. Configure
-# required reviewers on that environment (Settings > Environments) so each
-# release needs manual approval — this keeps the public repo safe.
-#
-# Reminder: bump versionCode/versionName (gradle.properties) and
-# CURRENT_PROJECT_VERSION/MARKETING_VERSION (Config.xcconfig) before releasing.
+# Secrets live exclusively in the `Production` environment.
 
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "Version X.Y.Z — leave blank to auto-infer from commits"
+        type: string
+        required: false
       platforms:
         description: "Platforms to release"
         type: choice
@@ -33,25 +39,49 @@ on:
           - alpha
           - internal
         default: production
-  push:
-    tags:
-      - 'v*'
+
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:
+  plan:
+    name: Plan release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      version_code: ${{ steps.resolve.outputs.version_code }}
+      branch: ${{ steps.resolve.outputs.branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: resolve
+        run: ./scripts/suggest-version.sh "${{ inputs.version }}"
+
   android:
     name: Android — Google Play
-    if: ${{ github.event_name == 'push' || github.event.inputs.platforms == 'both' || github.event.inputs.platforms == 'android' }}
+    needs: plan
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'android' }}
     runs-on: ubuntu-latest
     environment: Production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 1
+
+      - name: Bump version
+        run: ./scripts/bump-version.sh "${{ needs.plan.outputs.version }}" "${{ needs.plan.outputs.version_code }}"
 
       - name: Setup Gradle and Java
         uses: ./.github/actions/gradle
@@ -75,7 +105,7 @@ jobs:
           printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-service-account.json"
 
       - name: Build and upload to Google Play
-        run: fastlane android release track:"${{ github.event.inputs.track || 'production' }}"
+        run: fastlane android release track:"${{ inputs.track }}"
         env:
           ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -85,14 +115,19 @@ jobs:
 
   ios:
     name: iOS — App Store Connect
-    if: ${{ github.event_name == 'push' || github.event.inputs.platforms == 'both' || github.event.inputs.platforms == 'ios' }}
+    needs: plan
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'ios' }}
     runs-on: macos-latest
     environment: Production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 1
+
+      - name: Bump version
+        run: ./scripts/bump-version.sh "${{ needs.plan.outputs.version }}" "${{ needs.plan.outputs.version_code }}"
 
       - name: Setup Gradle and Java
         uses: ./.github/actions/gradle
@@ -127,3 +162,46 @@ jobs:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/match_ci_ssh -o IdentitiesOnly=yes
+
+  finalize:
+    name: Tag, release notes and merge-back
+    needs: [plan, android, ios]
+    if: ${{ inputs.platforms == 'both' && inputs.track == 'production' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Create release branch with version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ needs.plan.outputs.branch }}"
+          ./scripts/bump-version.sh "${{ needs.plan.outputs.version }}" "${{ needs.plan.outputs.version_code }}"
+          git commit -am "chore: bump version to ${{ needs.plan.outputs.version }}"
+          git push -u origin "${{ needs.plan.outputs.branch }}"
+
+      - name: Open merge-back PR and squash into main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ needs.plan.outputs.branch }}" \
+            --title "chore: merge back ${{ needs.plan.outputs.version }} into main" \
+            --body "Merges the ${{ needs.plan.outputs.version }} release (build ${{ needs.plan.outputs.version_code }}) back into main." \
+            --label enhancement \
+            --assignee "${{ github.actor }}"
+          gh pr merge "${{ needs.plan.outputs.branch }}" --squash --delete-branch
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.plan.outputs.version }}" \
+            --target main \
+            --title "v${{ needs.plan.outputs.version }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ on:
           - alpha
           - internal
         default: production
+      submit_ios_for_review:
+        description: "Submit the iOS build for App Store review (uncheck for a test run)"
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -162,6 +166,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/match_ci_ssh -o IdentitiesOnly=yes
+          SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
 
   finalize:
     name: Tag, release notes and merge-back

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ on:
           - alpha
           - internal
         default: production
+      complete_android_release:
+        description: "Roll out the Android release (uncheck to upload it as a draft)"
+        type: boolean
+        default: true
       submit_ios_for_review:
         description: "Submit the iOS build for App Store review (uncheck for a test run)"
         type: boolean
@@ -116,6 +120,7 @@ jobs:
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           PLAY_STORE_JSON_KEY_PATH: ${{ runner.temp }}/play-service-account.json
+          COMPLETE_RELEASE: ${{ inputs.complete_android_release }}
 
   ios:
     name: iOS — App Store Connect

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: release
 #   - Manually from the Actions tab (workflow_dispatch), choosing platform/track.
 #   - Pushing a version tag (e.g. v1.14.0).
 #
-# Secrets are exposed only to the `production` environment. Configure
+# Secrets are exposed only to the `Production` environment. Configure
 # required reviewers on that environment (Settings > Environments) so each
 # release needs manual approval — this keeps the public repo safe.
 #
@@ -46,7 +46,7 @@ jobs:
     name: Android — Google Play
     if: ${{ github.event_name == 'push' || github.event.inputs.platforms == 'both' || github.event.inputs.platforms == 'android' }}
     runs-on: ubuntu-latest
-    environment: production
+    environment: Production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
     name: iOS — App Store Connect
     if: ${{ github.event_name == 'push' || github.event.inputs.platforms == 'both' || github.event.inputs.platforms == 'ios' }}
     runs-on: macos-latest
-    environment: production
+    environment: Production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ setup-java.sh
 # Firebase
 androidApp/google-services.json
 iosApp/iosApp/GoogleService-Info.plist
+
+# fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+fastlane/README.md
+**/*.mobileprovision

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 fastlane/README.md
+fastlane/metadata/
 **/*.mobileprovision

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -29,9 +29,11 @@ android {
     }
     signingConfigs {
         create("release") {
-            // Populated only on CI, where the release workflow exports these
-            // variables after decoding the keystore from GitHub secrets.
-            // Local builds leave them unset and fall back to debug signing.
+            /*
+             * Populated only on CI, where the release workflow exports these
+             * variables after decoding the keystore from GitHub secrets.
+             * Local builds leave them unset and fall back to debug signing.
+             */
             val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
             if (keystorePath != null) {
                 storeFile = file(keystorePath)
@@ -50,9 +52,11 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
-            // Bundle native debug symbols into the AAB so Google Play can
-            // symbolicate native crash stack traces. Stripped from the user
-            // download, so it has no impact on the delivered app size.
+            /*
+             * Bundle native debug symbols into the AAB so Google Play can
+             * symbolicate native crash stack traces. Stripped from the user
+             * download, so it has no impact on the delivered app size.
+             */
             ndk {
                 debugSymbolLevel = "FULL"
             }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -50,6 +50,12 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            // Bundle native debug symbols into the AAB so Google Play can
+            // symbolicate native crash stack traces. Stripped from the user
+            // download, so it has no impact on the delivered app size.
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
         }
     }
 }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -27,11 +27,29 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    signingConfigs {
+        create("release") {
+            // Populated only on CI, where the release workflow exports these
+            // variables after decoding the keystore from GitHub secrets.
+            // Local builds leave them unset and fall back to debug signing.
+            val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (System.getenv("ANDROID_KEYSTORE_PATH") != null) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,171 @@
+# Release Process
+
+This document explains how Bible Planner is released to the **Google Play Store** and the
+**Apple App Store** through the automated pipeline defined in
+[`.github/workflows/release.yml`](../.github/workflows/release.yml).
+
+## Overview
+
+A release is a single manual action: you run the **release** workflow from the GitHub Actions
+tab. The pipeline resolves the version, pauses for your approval, builds and uploads both apps,
+and then tags the release and merges the version bump back into `main`.
+
+Nothing is created or published before you approve the run, and all credentials live in the
+`Production` GitHub Environment — only jobs that pass the approval gate can read them.
+
+## Pipeline at a glance
+
+```mermaid
+flowchart TD
+    A([Trigger: Run workflow]) --> B[plan<br/>resolve version]
+    B --> G{{Production gate<br/>manual approval}}
+    G -->|rejected| X([Run stops — nothing built])
+    G -->|approved| D[android<br/>build AAB + upload to Play]
+    G -->|approved| E[ios<br/>build IPA + submit to App Store]
+    D --> F[finalize]
+    E --> F
+    F --> F1[Create release/X.Y.Z branch + version bump]
+    F1 --> F2[Open + squash-merge the merge-back PR into main]
+    F2 --> F3([Publish GitHub Release vX.Y.Z])
+```
+
+| Job | Runner | Gated | What it does |
+|-----|--------|-------|--------------|
+| `plan` | ubuntu | no | Resolves the version and shows it in the run summary |
+| `android` | ubuntu | yes | Builds the signed AAB and uploads it to Google Play |
+| `ios` | macOS | yes | Builds the signed IPA, uploads it and submits it for App Store review |
+| `finalize` | ubuntu | no | Branch + version bump, merge-back PR, GitHub Release |
+
+## Triggering a release
+
+1. Make sure the in-app release notes JSON has an entry for the upcoming version
+   (see [Release notes](#release-notes-whats-new)).
+2. Open **GitHub → Actions → release → Run workflow**.
+3. Fill in the inputs (all optional):
+   - **version** — leave blank to auto-resolve, or type an explicit `X.Y.Z`.
+   - **platforms** — `both` (default), `android`, or `ios`.
+   - **track** — Android Play Store track: `production` (default), `beta`, `alpha`, `internal`.
+4. Click **Run workflow**.
+5. The `plan` job runs and prints the resolved version in the run summary. The run then pauses
+   on the **Production** environment.
+6. Open the run, review the planned version, and **approve** (or **reject** and start over).
+7. The build, upload and finalize steps run automatically.
+
+### Example — full production release of 1.14.0
+
+```text
+version:   (blank — auto-resolved to 1.14.0 from the release notes JSON)
+platforms: both
+track:     production
+```
+
+### Example — safe test release to internal track (Android only)
+
+```text
+version:   (blank)
+platforms: android
+track:     internal
+```
+
+The `finalize` job only runs for `platforms = both` **and** `track = production`, so test runs
+upload a build without creating a tag, GitHub Release or merge-back PR.
+
+## How the version is resolved
+
+The `plan` job runs [`scripts/suggest-version.sh`](../scripts/suggest-version.sh), which picks
+the version in this order:
+
+```mermaid
+flowchart TD
+    A([Resolve version]) --> B{version input<br/>provided?}
+    B -->|yes| C[Use the input]
+    B -->|no| D{Release notes JSON<br/>ahead of the released version?}
+    D -->|yes| E[Use the JSON's highest version key]
+    D -->|no| F[Infer from commits since the last release:<br/>any feature or feat commit gives a minor bump<br/>otherwise a patch bump]
+```
+
+- The **`versionCode`** (Android) / **`CURRENT_PROJECT_VERSION`** (iOS) is always the current
+  value **+ 1**.
+- The release notes JSON is the preferred source: its newest key is the version the team has
+  been accumulating notes for, so the version and the "What's New" come from the same place.
+
+## Release notes ("What's New")
+
+Release notes live in three JSON files, keyed by version:
+
+```
+feature/release_notes/src/commonMain/composeResources/files/release_notes/{en,pt,es}.json
+```
+
+```json
+{
+  "1.14.0": [
+    "You can now change the app language from the 'More' screen.",
+    "Fixed extra whitespace below the search bar."
+  ]
+}
+```
+
+Keep them updated during the development cycle with the `release-notes-updater` skill. At
+release time the pipeline reads the entry for the version being shipped and publishes it as the
+store "What's New":
+
+- **Google Play** — written as changelog files for every listing locale (`en-US`, `pt-BR`,
+  `es-419`, `es-ES`, `es-US`).
+- **App Store** — the listing's locales are discovered at runtime via the App Store Connect API,
+  and the notes are matched by language.
+
+If no JSON entry exists for the version, the build still ships — the store "What's New" is just
+left unchanged.
+
+## Approval gate
+
+The `android` and `ios` jobs target the `Production` GitHub Environment, which has **required
+reviewers**. The run pauses before those jobs until a reviewer approves it. Because `plan` has
+already run, the reviewer can see the resolved version in the run summary before approving.
+
+To use a different version than the one resolved, **reject** the run and start a new one with
+the `version` input set.
+
+## After a release
+
+Once both store uploads succeed, `finalize`:
+
+1. Creates the `release/X.Y.Z` branch with the version bump commit (Android, iOS and Desktop —
+   see [`scripts/bump-version.sh`](../scripts/bump-version.sh)).
+2. Opens a `chore: merge back X.Y.Z into main` pull request and squash-merges it into `main`.
+3. Publishes a **GitHub Release** `vX.Y.Z` with auto-generated notes.
+
+## If a store rejects the build
+
+Apple/Google review is still a human gate and can reject a build. If that happens, fix the code
+and ship it as the next version — the rejected version's GitHub Release/tag can simply be
+deleted. The version code is already consumed, which is fine: version codes only need to keep
+increasing.
+
+## Manual version bump (local)
+
+To bump versions outside the pipeline (Android, iOS and Desktop at once):
+
+```bash
+./scripts/bump-version.sh 1.14.0 23
+#                          │      └─ versionCode
+#                          └──────── versionName
+```
+
+## Configuration reference
+
+| Item | Value |
+|------|-------|
+| Workflow | `.github/workflows/release.yml` |
+| Fastlane lanes | `fastlane/Fastfile` (`android release`, `ios release`) |
+| iOS certificates | fastlane match — private repo `bible-planner-certs` |
+| Approval gate | `Production` GitHub Environment (required reviewers) |
+
+All secrets are stored in the `Production` environment, never committed:
+
+`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`,
+`ANDROID_KEY_PASSWORD`, `PLAY_STORE_SERVICE_ACCOUNT_JSON`, `GOOGLE_SERVICES_JSON`,
+`GOOGLE_SERVICE_INFO_PLIST`, `APP_STORE_CONNECT_API_KEY_ID`,
+`APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8`, `MATCH_PASSWORD`,
+`MATCH_SSH_PRIVATE_KEY`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -45,6 +45,8 @@ flowchart TD
    - **version** — leave blank to auto-resolve, or type an explicit `X.Y.Z`.
    - **platforms** — `both` (default), `android`, or `ios`.
    - **track** — Android Play Store track: `production` (default), `beta`, `alpha`, `internal`.
+   - **complete_android_release** — `true` (default) rolls the Android release out; `false`
+     uploads it to the track as a draft you release manually from the Play Console.
    - **submit_ios_for_review** — `true` (default) submits the iOS build for App Store review;
      `false` only uploads it to App Store Connect / TestFlight (use it for test runs).
 4. Click **Run workflow**.
@@ -56,24 +58,27 @@ flowchart TD
 ### Example — full production release of 1.14.0
 
 ```text
-version:               (blank — auto-resolved to 1.14.0 from the release notes JSON)
-platforms:             both
-track:                 production
-submit_ios_for_review: true
+version:                  (blank — auto-resolved to 1.14.0 from the release notes JSON)
+platforms:                both
+track:                    production
+complete_android_release: true
+submit_ios_for_review:    true
 ```
 
 ### Example — safe test run (no production impact)
 
 ```text
-version:               (blank)
-platforms:             both
-track:                 internal
-submit_ios_for_review: false
+version:                  (blank)
+platforms:                both
+track:                    internal
+complete_android_release: false
+submit_ios_for_review:    false
 ```
 
-Android uploads to the internal testing track and iOS lands in App Store Connect / TestFlight
-without being submitted for review. The `finalize` job only runs for `platforms = both` **and**
-`track = production`, so a test run creates no tag, GitHub Release or merge-back PR.
+Android uploads to the internal testing track as a draft and iOS lands in App Store Connect /
+TestFlight without being submitted for review. The `finalize` job only runs for
+`platforms = both` **and** `track = production`, so a test run creates no tag, GitHub Release or
+merge-back PR.
 
 ## How the version is resolved
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -45,6 +45,8 @@ flowchart TD
    - **version** — leave blank to auto-resolve, or type an explicit `X.Y.Z`.
    - **platforms** — `both` (default), `android`, or `ios`.
    - **track** — Android Play Store track: `production` (default), `beta`, `alpha`, `internal`.
+   - **submit_ios_for_review** — `true` (default) submits the iOS build for App Store review;
+     `false` only uploads it to App Store Connect / TestFlight (use it for test runs).
 4. Click **Run workflow**.
 5. The `plan` job runs and prints the resolved version in the run summary. The run then pauses
    on the **Production** environment.
@@ -54,21 +56,24 @@ flowchart TD
 ### Example — full production release of 1.14.0
 
 ```text
-version:   (blank — auto-resolved to 1.14.0 from the release notes JSON)
-platforms: both
-track:     production
+version:               (blank — auto-resolved to 1.14.0 from the release notes JSON)
+platforms:             both
+track:                 production
+submit_ios_for_review: true
 ```
 
-### Example — safe test release to internal track (Android only)
+### Example — safe test run (no production impact)
 
 ```text
-version:   (blank)
-platforms: android
-track:     internal
+version:               (blank)
+platforms:             both
+track:                 internal
+submit_ios_for_review: false
 ```
 
-The `finalize` job only runs for `platforms = both` **and** `track = production`, so test runs
-upload a build without creating a tag, GitHub Release or merge-back PR.
+Android uploads to the internal testing track and iOS lands in App Store Connect / TestFlight
+without being submitted for review. The `finalize` job only runs for `platforms = both` **and**
+`track = production`, so a test run creates no tag, GitHub Release or merge-back PR.
 
 ## How the version is resolved
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,5 @@
+# Appfile — shared identifiers for fastlane
+# https://docs.fastlane.tools/advanced/#appfile
+
+app_identifier("com.quare.bibleplanner.BiblePlanner") # iOS bundle identifier
+package_name("com.quare.bibleplanner")                # Android applicationId

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,15 +78,19 @@ def stage_play_changelogs(version, version_code)
   return false if notes.empty?
 
   written = false
-  { "en" => "en-US", "pt" => "pt-BR", "es" => "es-419" }.each do |lang, locale|
+  # Play Store listing locales. Spanish notes are reused across every Spanish
+  # variant the listing supports.
+  { "en" => ["en-US"], "pt" => ["pt-BR"], "es" => ["es-419", "es-ES", "es-US"] }.each do |lang, locales|
     text = notes[lang]
     next unless text
 
-    dir = File.join("fastlane", "metadata", "android", locale, "changelogs")
-    FileUtils.mkdir_p(dir)
-    File.write(File.join(dir, "#{version_code}.txt"), text)
-    UI.message("Staged Play changelog for #{locale}")
-    written = true
+    locales.each do |locale|
+      dir = File.join("fastlane", "metadata", "android", locale, "changelogs")
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, "#{version_code}.txt"), text)
+      UI.message("Staged Play changelog for #{locale}")
+      written = true
+    end
   end
   written
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -207,15 +207,18 @@ platform :ios do
       UI.error("Could not prepare release notes, continuing without them: #{e.message}")
     end
 
-    # Uploads the build, submits it for Apple review and releases it
-    # automatically once approved. Apple review is still a human gate and may
-    # reject the build — ship a fix as the next version if that happens.
+    # Uploads the build to App Store Connect. When SUBMIT_FOR_REVIEW is true the
+    # build is also submitted for Apple review and auto-released once approved;
+    # when false it only lands in App Store Connect / TestFlight (safe for test
+    # runs). Apple review can still reject — ship a fix as a new version.
+    submit = ENV.fetch("SUBMIT_FOR_REVIEW", "true").strip.downcase == "true"
+
     upload_to_app_store(
       api_key: api_key,
       skip_metadata: !has_release_notes,
       skip_screenshots: true,
-      submit_for_review: true,
-      automatic_release: true,
+      submit_for_review: submit,
+      automatic_release: submit,
       force: true,
       precheck_include_in_app_purchases: false,
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,19 +3,72 @@
 #
 # These lanes are designed to run on GitHub Actions (see .github/workflows/release.yml).
 # All credentials are provided through environment variables / GitHub secrets.
-#
-# NOTE: bump `versionCode` / `versionName` in gradle.properties and
-# `CURRENT_PROJECT_VERSION` / `MARKETING_VERSION` in iosApp/Configuration/Config.xcconfig
-# before triggering a release — stores reject an already-published version.
 
 opt_out_usage
 skip_docs
+
+require "json"
 
 APP_BUNDLE_ID    = "com.quare.bibleplanner.BiblePlanner".freeze
 WIDGET_BUNDLE_ID = "com.quare.bibleplanner.BiblePlanner.BibleDownloadWidget".freeze
 ANDROID_PACKAGE  = "com.quare.bibleplanner".freeze
 APPLE_TEAM_ID    = "TTV2A365LG".freeze
 XCODE_PROJECT    = "iosApp/iosApp.xcodeproj".freeze
+XCCONFIG         = "iosApp/Configuration/Config.xcconfig".freeze
+RELEASE_NOTES_DIR = "feature/release_notes/src/commonMain/composeResources/files/release_notes".freeze
+
+# Reads the in-app release notes JSON files and returns the notes for the given
+# version as { "en" => "text", "pt" => "text", "es" => "text" } (one line per item).
+def release_notes_for_version(version)
+  notes = {}
+  { "en" => "en.json", "pt" => "pt.json", "es" => "es.json" }.each do |lang, file|
+    path = File.join(RELEASE_NOTES_DIR, file)
+    next unless File.exist?(path)
+
+    items = JSON.parse(File.read(path))[version]
+    notes[lang] = items.join("\n") if items.is_a?(Array) && !items.empty?
+  end
+  notes
+end
+
+# Lists the locales of the app's App Store listing (e.g. ["en-US", "pt-BR", "es-MX"]).
+def app_store_listing_locales(api_key)
+  require "spaceship"
+  Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
+    key_id: api_key[:key_id],
+    issuer_id: api_key[:issuer_id],
+    key: api_key[:key],
+  )
+  app = Spaceship::ConnectAPI::App.find(APP_BUNDLE_ID)
+  version = app.get_live_app_store_version || app.get_edit_app_store_version
+  version.get_app_store_version_localizations.map(&:locale)
+end
+
+# Writes fastlane/metadata/<locale>/release_notes.txt for every App Store locale
+# that has matching in-app release notes. Returns true if any file was written.
+# The "What's New" text is sourced from the in-app release notes JSON, keyed by
+# the version currently set in Config.xcconfig.
+def stage_release_notes(api_key)
+  version = File.read(XCCONFIG)[/^MARKETING_VERSION=(.+)$/, 1]&.strip
+  notes = release_notes_for_version(version)
+  if notes.empty?
+    UI.important("No in-app release notes found for #{version} — App Store 'What's New' will be left unchanged.")
+    return false
+  end
+
+  written = false
+  app_store_listing_locales(api_key).each do |locale|
+    text = notes[locale.split("-").first.downcase]
+    next unless text
+
+    dir = File.join("fastlane", "metadata", locale)
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, "release_notes.txt"), text)
+    UI.message("Staged 'What's New' for #{locale}")
+    written = true
+  end
+  written
+end
 
 # ---------------------------------------------------------------------------
 # Android
@@ -74,7 +127,7 @@ platform :ios do
 
     # Switch the Release configuration to manual signing at build time only.
     # The committed project keeps automatic signing, so local development is
-    # unaffected (option B agreed for this pipeline).
+    # unaffected.
     update_code_signing_settings(
       use_automatic_signing: false,
       path: XCODE_PROJECT,
@@ -108,12 +161,21 @@ platform :ios do
       },
     )
 
+    # Build the App Store "What's New" from the in-app release notes JSON.
+    # Non-fatal: a failure here must not block shipping the build.
+    has_release_notes = false
+    begin
+      has_release_notes = stage_release_notes(api_key)
+    rescue => e
+      UI.error("Could not prepare release notes, continuing without them: #{e.message}")
+    end
+
     # Uploads the build, submits it for Apple review and releases it
     # automatically once approved. Apple review is still a human gate and may
     # reject the build — ship a fix as the next version if that happens.
     upload_to_app_store(
       api_key: api_key,
-      skip_metadata: true,
+      skip_metadata: !has_release_notes,
       skip_screenshots: true,
       submit_for_review: true,
       automatic_release: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,14 +108,16 @@ platform :ios do
       },
     )
 
-    # Uploads the build to App Store Connect. It does NOT auto-submit for
-    # Apple review — submit the build from App Store Connect once it finishes
-    # processing. Flip submit_for_review to true if you want CI to submit.
+    # Uploads the build, submits it for Apple review and releases it
+    # automatically once approved. Apple review is still a human gate and may
+    # reject the build — ship a fix as the next version if that happens.
     upload_to_app_store(
       api_key: api_key,
       skip_metadata: true,
       skip_screenshots: true,
-      submit_for_review: false,
+      submit_for_review: true,
+      automatic_release: true,
+      force: true,
       precheck_include_in_app_purchases: false,
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -122,10 +122,14 @@ platform :android do
       UI.error("Could not prepare Play changelogs, continuing without them: #{e.message}")
     end
 
+    # "completed" rolls the release out to the track; "draft" uploads the
+    # build without releasing it, to be released manually from the Play Console.
+    release_status = ENV.fetch("COMPLETE_RELEASE", "true").strip.downcase == "true" ? "completed" : "draft"
+
     upload_to_play_store(
       package_name: ANDROID_PACKAGE,
       track: track,
-      release_status: "completed",
+      release_status: release_status,
       aab: "androidApp/build/outputs/bundle/release/androidApp-release.aab",
       json_key: ENV.fetch("PLAY_STORE_JSON_KEY_PATH"),
       skip_upload_metadata: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,122 @@
+# Fastfile — CI/CD lanes for Bible Planner
+# https://docs.fastlane.tools/
+#
+# These lanes are designed to run on GitHub Actions (see .github/workflows/release.yml).
+# All credentials are provided through environment variables / GitHub secrets.
+#
+# NOTE: bump `versionCode` / `versionName` in gradle.properties and
+# `CURRENT_PROJECT_VERSION` / `MARKETING_VERSION` in iosApp/Configuration/Config.xcconfig
+# before triggering a release — stores reject an already-published version.
+
+opt_out_usage
+skip_docs
+
+APP_BUNDLE_ID    = "com.quare.bibleplanner.BiblePlanner".freeze
+WIDGET_BUNDLE_ID = "com.quare.bibleplanner.BiblePlanner.BibleDownloadWidget".freeze
+ANDROID_PACKAGE  = "com.quare.bibleplanner".freeze
+APPLE_TEAM_ID    = "TTV2A365LG".freeze
+XCODE_PROJECT    = "iosApp/iosApp.xcodeproj".freeze
+
+# ---------------------------------------------------------------------------
+# Android
+# ---------------------------------------------------------------------------
+platform :android do
+  desc "Build a signed release AAB and upload it to Google Play"
+  desc "Options: track (production|beta|alpha|internal) — defaults to production"
+  lane :release do |options|
+    track = options[:track] || "production"
+
+    # Release signing is wired in androidApp/build.gradle.kts and reads the
+    # ANDROID_KEYSTORE_* environment variables exported by the workflow.
+    gradle(
+      task: ":androidApp:bundleRelease",
+    )
+
+    upload_to_play_store(
+      package_name: ANDROID_PACKAGE,
+      track: track,
+      release_status: "completed",
+      aab: "androidApp/build/outputs/bundle/release/androidApp-release.aab",
+      json_key: ENV.fetch("PLAY_STORE_JSON_KEY_PATH"),
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+  end
+end
+
+# ---------------------------------------------------------------------------
+# iOS
+# ---------------------------------------------------------------------------
+platform :ios do
+  desc "Build a signed release IPA and upload it to App Store Connect"
+  lane :release do
+    # Creates an isolated temporary keychain on CI so signing never touches
+    # the machine's login keychain. No-op when running outside CI.
+    setup_ci
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id: ENV.fetch("APP_STORE_CONNECT_API_ISSUER_ID"),
+      key_content: ENV.fetch("APP_STORE_CONNECT_API_KEY_P8"),
+      is_key_content_base64: true,
+    )
+
+    # Fetch the distribution certificate + provisioning profiles from the
+    # private certs repo (configured in fastlane/Matchfile). readonly: the CI
+    # never creates or revokes anything — that is done locally by an admin.
+    match(
+      type: "appstore",
+      readonly: true,
+      api_key: api_key,
+    )
+
+    # Switch the Release configuration to manual signing at build time only.
+    # The committed project keeps automatic signing, so local development is
+    # unaffected (option B agreed for this pipeline).
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: XCODE_PROJECT,
+      team_id: APPLE_TEAM_ID,
+      targets: ["iosApp"],
+      code_sign_identity: "Apple Distribution",
+      profile_name: "match AppStore #{APP_BUNDLE_ID}",
+      build_configurations: ["Release"],
+    )
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: XCODE_PROJECT,
+      team_id: APPLE_TEAM_ID,
+      targets: ["BibleDownloadWidgetExtension"],
+      code_sign_identity: "Apple Distribution",
+      profile_name: "match AppStore #{WIDGET_BUNDLE_ID}",
+      build_configurations: ["Release"],
+    )
+
+    build_app(
+      project: XCODE_PROJECT,
+      scheme: "iosApp",
+      configuration: "Release",
+      export_method: "app-store",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: {
+          APP_BUNDLE_ID    => "match AppStore #{APP_BUNDLE_ID}",
+          WIDGET_BUNDLE_ID => "match AppStore #{WIDGET_BUNDLE_ID}",
+        },
+      },
+    )
+
+    # Uploads the build to App Store Connect. It does NOT auto-submit for
+    # Apple review — submit the build from App Store Connect once it finishes
+    # processing. Flip submit_for_review to true if you want CI to submit.
+    upload_to_app_store(
+      api_key: api_key,
+      skip_metadata: true,
+      skip_screenshots: true,
+      submit_for_review: false,
+      precheck_include_in_app_purchases: false,
+    )
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,6 +70,27 @@ def stage_release_notes(api_key)
   written
 end
 
+# Writes fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt from
+# the in-app release notes JSON, so Google Play shows the same "What's new".
+# Returns true if any file was written.
+def stage_play_changelogs(version, version_code)
+  notes = release_notes_for_version(version)
+  return false if notes.empty?
+
+  written = false
+  { "en" => "en-US", "pt" => "pt-BR", "es" => "es-419" }.each do |lang, locale|
+    text = notes[lang]
+    next unless text
+
+    dir = File.join("fastlane", "metadata", "android", locale, "changelogs")
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, "#{version_code}.txt"), text)
+    UI.message("Staged Play changelog for #{locale}")
+    written = true
+  end
+  written
+end
+
 # ---------------------------------------------------------------------------
 # Android
 # ---------------------------------------------------------------------------
@@ -85,6 +106,18 @@ platform :android do
       task: ":androidApp:bundleRelease",
     )
 
+    # Build the Play "What's new" from the in-app release notes JSON, keyed by
+    # the version currently set in gradle.properties. Non-fatal on failure.
+    props = File.read("gradle.properties")
+    version = props[/^versionName=(.+)$/, 1]&.strip
+    version_code = props[/^versionCode=(.+)$/, 1]&.strip
+    has_changelogs = false
+    begin
+      has_changelogs = stage_play_changelogs(version, version_code)
+    rescue => e
+      UI.error("Could not prepare Play changelogs, continuing without them: #{e.message}")
+    end
+
     upload_to_play_store(
       package_name: ANDROID_PACKAGE,
       track: track,
@@ -92,7 +125,7 @@ platform :android do
       aab: "androidApp/build/outputs/bundle/release/androidApp-release.aab",
       json_key: ENV.fetch("PLAY_STORE_JSON_KEY_PATH"),
       skip_upload_metadata: true,
-      skip_upload_changelogs: true,
+      skip_upload_changelogs: !has_changelogs,
       skip_upload_images: true,
       skip_upload_screenshots: true,
     )

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,0 +1,14 @@
+# fastlane match configuration
+# Docs: https://docs.fastlane.tools/actions/match/
+
+git_url("git@github.com:Quartel-Enterprise/bible-planner-certs.git")
+storage_mode("git")
+
+type("appstore")
+
+app_identifier([
+  "com.quare.bibleplanner.BiblePlanner",
+  "com.quare.bibleplanner.BiblePlanner.BibleDownloadWidget"
+])
+
+team_id("TTV2A365LG")

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1700"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "56840B38DE147884B99A2817"
+               BuildableName = "BiblePlanner.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "56840B38DE147884B99A2817"
+            BuildableName = "BiblePlanner.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Bumps the app version across all platforms.
+#
+# Usage: scripts/bump-version.sh <versionName> <versionCode>
+#   versionName  e.g. 1.14.0  — Android versionName / iOS MARKETING_VERSION / Desktop packageVersion
+#   versionCode  e.g. 23      — Android versionCode  / iOS CURRENT_PROJECT_VERSION
+#
+# Touches exactly three files (Android, iOS, Desktop), matching the
+# established release bump commit.
+set -euo pipefail
+
+version="${1:?versionName required (e.g. 1.14.0)}"
+code="${2:?versionCode required (e.g. 23)}"
+
+# Run from the repository root regardless of the caller's working directory.
+cd "$(dirname "$0")/.."
+
+# Android — gradle.properties
+sed -i.bak -E "s/^versionCode=.*/versionCode=${code}/" gradle.properties
+sed -i.bak -E "s/^versionName=.*/versionName=${version}/" gradle.properties
+
+# iOS — Configuration/Config.xcconfig
+sed -i.bak -E "s/^CURRENT_PROJECT_VERSION=.*/CURRENT_PROJECT_VERSION=${code}/" iosApp/Configuration/Config.xcconfig
+sed -i.bak -E "s/^MARKETING_VERSION=.*/MARKETING_VERSION=${version}/" iosApp/Configuration/Config.xcconfig
+
+# Desktop — composeApp/build.gradle.kts
+sed -i.bak -E "s/packageVersion = \"[^\"]*\"/packageVersion = \"${version}\"/" composeApp/build.gradle.kts
+
+rm -f gradle.properties.bak \
+      iosApp/Configuration/Config.xcconfig.bak \
+      composeApp/build.gradle.kts.bak
+
+echo "Bumped version to ${version} (versionCode ${code})"

--- a/scripts/suggest-version.sh
+++ b/scripts/suggest-version.sh
@@ -2,9 +2,14 @@
 # Resolves the version for a release run.
 #
 # Usage: scripts/suggest-version.sh [versionName]
-#   versionName given  -> used as-is.
-#   versionName omitted -> inferred from Conventional Commit prefixes since
-#   the last release: any feature/feat commit -> minor bump, otherwise patch.
+#
+# Resolution order:
+#   1. The versionName argument, if provided.
+#   2. The highest version key in the in-app release notes JSON, when it is
+#      ahead of the currently released version — this is the team's declared
+#      next version and also the source of the App Store "What's New".
+#   3. Otherwise inferred from Conventional Commit prefixes since the last
+#      release: any feature/feat commit -> minor bump, otherwise patch.
 #
 # versionCode is always the current value + 1.
 #
@@ -13,6 +18,8 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+EN_JSON="feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json"
 
 input_version="${1:-}"
 
@@ -25,9 +32,20 @@ current_version="$(grep -E '^versionName=' gradle.properties | cut -d= -f2)"
 current_code="$(grep -E '^versionCode=' gradle.properties | cut -d= -f2)"
 next_code=$(( current_code + 1 ))
 
+# Highest X.Y.Z key declared in the release notes JSON ("" if none/unavailable).
+json_version="$(python3 -c "import json; ks=[k for k in json.load(open('$EN_JSON')) if k.count('.')==2 and k.replace('.','').isdigit()]; print(max(ks, key=lambda v: tuple(int(x) for x in v.split('.'))) if ks else '')" 2>/dev/null || true)"
+
+# is_higher A B -> succeeds when semver A is strictly greater than B.
+is_higher() {
+  [[ "$1" != "$2" && "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" == "$1" ]]
+}
+
 if [[ -n "$input_version" ]]; then
   version="$input_version"
   source_desc="provided manually via the workflow input"
+elif [[ -n "$json_version" ]] && is_higher "$json_version" "$current_version"; then
+  version="$json_version"
+  source_desc="taken from the release notes JSON (the team's declared next version)"
 else
   # Anchor = last v* tag, falling back to the last "merge back" commit.
   anchor="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
@@ -50,7 +68,7 @@ else
     patch=$(( patch + 1 ))
   fi
   version="${major}.${minor}.${patch}"
-  source_desc="inferred (${bump} bump from commits since ${anchor:-the start of history})"
+  source_desc="inferred (${bump} bump from commits — the release notes JSON has no newer version yet)"
 fi
 
 branch="release/${version}"

--- a/scripts/suggest-version.sh
+++ b/scripts/suggest-version.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Resolves the version for a release run.
+#
+# Usage: scripts/suggest-version.sh [versionName]
+#   versionName given  -> used as-is.
+#   versionName omitted -> inferred from Conventional Commit prefixes since
+#   the last release: any feature/feat commit -> minor bump, otherwise patch.
+#
+# versionCode is always the current value + 1.
+#
+# Inside GitHub Actions, writes `version`, `version_code` and `branch` to
+# $GITHUB_OUTPUT and a human-readable plan to $GITHUB_STEP_SUMMARY.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+input_version="${1:-}"
+
+if [[ -n "$input_version" && ! "$input_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: version '$input_version' must be in X.Y.Z format (e.g. 1.14.0)" >&2
+  exit 1
+fi
+
+current_version="$(grep -E '^versionName=' gradle.properties | cut -d= -f2)"
+current_code="$(grep -E '^versionCode=' gradle.properties | cut -d= -f2)"
+next_code=$(( current_code + 1 ))
+
+if [[ -n "$input_version" ]]; then
+  version="$input_version"
+  source_desc="provided manually via the workflow input"
+else
+  # Anchor = last v* tag, falling back to the last "merge back" commit.
+  anchor="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+  if [[ -z "$anchor" ]]; then
+    anchor="$(git log --grep='merge back' --format='%H' -n 1 2>/dev/null || true)"
+  fi
+  range="HEAD"
+  [[ -n "$anchor" ]] && range="${anchor}..HEAD"
+
+  if git log "$range" --format='%s' | grep -qiE '^(feat|feature)(\(.+\))?!?:'; then
+    bump="minor"
+  else
+    bump="patch"
+  fi
+
+  IFS='.' read -r major minor patch <<< "$current_version"
+  if [[ "$bump" == "minor" ]]; then
+    minor=$(( minor + 1 )); patch=0
+  else
+    patch=$(( patch + 1 ))
+  fi
+  version="${major}.${minor}.${patch}"
+  source_desc="inferred (${bump} bump from commits since ${anchor:-the start of history})"
+fi
+
+branch="release/${version}"
+
+echo "Resolved version: ${version} (versionCode ${next_code}) — ${source_desc}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "version=${version}"
+    echo "version_code=${next_code}"
+    echo "branch=${branch}"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Release plan"
+    echo ""
+    echo "| Field | Value |"
+    echo "|---|---|"
+    echo "| Version name | \`${version}\` |"
+    echo "| Version code | \`${next_code}\` |"
+    echo "| Release branch | \`${branch}\` |"
+    echo "| Source | ${source_desc} |"
+    echo ""
+    echo "Review this plan, then **approve the \`Production\` environment** to continue."
+    echo "To use a different version, reject this run and start a new one with the \`version\` input set."
+  } >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Summary

Adds a fully automated release pipeline that versions, builds and ships Bible Planner to both stores.

### How a release works

Run the **release** workflow from the Actions tab:

1. **`plan`** — resolves the version. Preference order: the `version` input, then the top key of the in-app release notes JSON (the team's declared next version), then a fallback inferred from Conventional Commit prefixes since the last release. versionCode is always +1. The resolved version is shown in the run summary.
2. **Approval gate** — the run pauses on the `Production` environment. Reviewers see the planned version in the summary and approve (or reject and re-run with an explicit `version`). Nothing is created before approval.
3. **`android` / `ios`** — bump the version locally, build, and upload to Google Play (`supply`) and App Store Connect (build + submit for review). The App Store "What's New" is sourced from the in-app release notes JSON; the listing's locales are discovered via the App Store Connect API at runtime.
4. **`finalize`** — creates the `release/X.Y.Z` branch with the version bump, opens and squash-merges the merge-back PR into `main`, and publishes the GitHub release with auto-generated notes.

### What's included

- **`.github/workflows/release.yml`** — the pipeline above.
- **`scripts/suggest-version.sh`** — resolves the next version (release notes JSON / commit history).
- **`scripts/bump-version.sh`** — bumps Android (`gradle.properties`), iOS (`Config.xcconfig`) and Desktop (`composeApp/build.gradle.kts`).
- **`fastlane/`** — Fastfile lanes for Android and iOS, plus Matchfile/Appfile.
- **Android signing** — `androidApp/build.gradle.kts` reads the keystore from env vars on CI, debug fallback locally.
- **iOS signing** — fastlane match; manual signing applied at build time only, so local dev is untouched. `ITSAppUsesNonExemptEncryption=false` added so review submission isn't blocked.
- **Shared iOS scheme** so CI can build it.

All credentials live in the `Production` environment secrets / a private certificates repo — nothing sensitive is committed.

## Follow-up before the first release

- Confirm the `Production` environment has required reviewers (approval gate).
- Keep the in-app release notes JSON updated for the upcoming version — it drives both the resolved version and the App Store "What's New".
- A store may reject review — that's fine, ship a fix as the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)