### PR TITLE
chore: provide local.properties to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
             --head "${{ needs.plan.outputs.branch }}" \
             --title "chore: merge back ${{ needs.plan.outputs.version }} into main" \
             --body "Merges the ${{ needs.plan.outputs.version }} release (build ${{ needs.plan.outputs.version_code }}) back into main." \
-            --label enhancement \
+            --label bump \
             --assignee "${{ github.actor }}"
           gh pr merge "${{ needs.plan.outputs.branch }}" --squash --delete-branch
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,12 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
           PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
           echo "$GOOGLE_SERVICES_JSON" | base64 --decode > androidApp/google-services.json
           printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-service-account.json"
+          printf '%s\n' "$LOCAL_PROPERTIES" > local.properties
 
       - name: Build and upload to Google Play
         run: fastlane android release track:"${{ inputs.track }}"
@@ -158,10 +160,13 @@ jobs:
           chmod 600 "$RUNNER_TEMP/match_ci_ssh"
           ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
 
-      - name: Decode Firebase config
+      - name: Decode Firebase config and local properties
         env:
           GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
-        run: echo "$GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > iosApp/iosApp/GoogleService-Info.plist
+          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+        run: |
+          echo "$GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > iosApp/iosApp/GoogleService-Info.plist
+          printf '%s\n' "$LOCAL_PROPERTIES" > local.properties
 
       - name: Build and upload to App Store Connect
         run: fastlane ios release

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -178,4 +178,9 @@ All secrets are stored in the `Production` environment, never committed:
 `ANDROID_KEY_PASSWORD`, `PLAY_STORE_SERVICE_ACCOUNT_JSON`, `GOOGLE_SERVICES_JSON`,
 `GOOGLE_SERVICE_INFO_PLIST`, `APP_STORE_CONNECT_API_KEY_ID`,
 `APP_STORE_CONNECT_API_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY_P8`, `MATCH_PASSWORD`,
-`MATCH_SSH_PRIVATE_KEY`.
+`MATCH_SSH_PRIVATE_KEY`, `LOCAL_PROPERTIES`.
+
+`LOCAL_PROPERTIES` holds the contents of `local.properties` (minus `sdk.dir`) — the
+build-time values consumed by BuildKonfig (Supabase, RevenueCat, donation addresses and the
+GitHub token). The workflow writes it to `local.properties` before building, since that file
+is git-ignored and would otherwise be missing on the runner.


### PR DESCRIPTION
## Summary

The release pipeline merged in #125 was missing one thing: the build-time
configuration that four modules read from `local.properties` via BuildKonfig.

`local.properties` is git-ignored, so on a CI runner it does not exist — the
build still succeeds but those values come out **empty**, which would ship a
broken app (Supabase content download and social login, RevenueCat purchases,
donation addresses).

This change reconstructs `local.properties` on the runner from a new
`LOCAL_PROPERTIES` environment secret, before the Android and iOS builds.

## Changes

- `release.yml` — the Android and iOS jobs write `local.properties` from the
  `LOCAL_PROPERTIES` secret during the decode step.
- `docs/release-process.md` — documents the new secret.

No build-script changes were needed: the modules already read `local.properties`
when it is present.

## Notes

- `LOCAL_PROPERTIES` (without `sdk.dir`) is stored in the `Production` environment.
- Keys covered: `SUPABASE_*`, `REVENUECAT_*`, `BTC_*` / `USDT_*` / `PIX_KEY`, `GH_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)