### PR TITLE
refactor: replace deprecated androidLibrary block with android

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 kotlin {
     val androidSdkVersions = getAndroidSdkVersions()
-    androidLibrary {
+    android {
         compileSdk = androidSdkVersions.compileSdk
         minSdk = androidSdkVersions.minSdk
         namespace = "com.quare.bibleplanner.shared"

--- a/core/books/build.gradle.kts
+++ b/core/books/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.books"
     }
 

--- a/core/date/build.gradle.kts
+++ b/core/date/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.date"
     }
     jvm()

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.model"
     }
     jvm()

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.navigation"
     }
 

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.network"
     }
     jvm()

--- a/core/notification/build.gradle.kts
+++ b/core/notification/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.notification"
     }
 

--- a/core/plan/build.gradle.kts
+++ b/core/plan/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.plan"
     }
 

--- a/core/provider/billing/build.gradle.kts
+++ b/core/provider/billing/build.gradle.kts
@@ -36,7 +36,7 @@ buildkonfig {
 private fun getRevenueErrorMessage(keyName: String): String =
     "⚠️ $keyName not found in local.properties. RevenueCat features will not work correctly. See docs/setup_revenuecat.md for setup instructions."
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.billing"
     }
 

--- a/core/provider/data_store/build.gradle.kts
+++ b/core/provider/data_store/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.datastore"
     }
 

--- a/core/provider/koin/build.gradle.kts
+++ b/core/provider/koin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.koin"
     }
 

--- a/core/provider/language/build.gradle.kts
+++ b/core/provider/language/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.language"
     }
 

--- a/core/provider/platform/build.gradle.kts
+++ b/core/provider/platform/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.platform"
     }
 

--- a/core/provider/room/build.gradle.kts
+++ b/core/provider/room/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.room"
     }
 

--- a/core/provider/supabase/build.gradle.kts
+++ b/core/provider/supabase/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.provider.supabase"
     }
     jvm()

--- a/core/remote_config/build.gradle.kts
+++ b/core/remote_config/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.remoteconfig"
     }
 

--- a/core/user/build.gradle.kts
+++ b/core/user/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.user"
     }
     jvm()

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.utils"
     }
 

--- a/core/utils/json_reader/build.gradle.kts
+++ b/core/utils/json_reader/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.core.utils.jsonreader"
     }
 

--- a/feature/add_notes_free_warning/build.gradle.kts
+++ b/feature/add_notes_free_warning/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.addnotesfreewarning"
     }
 

--- a/feature/book_details/build.gradle.kts
+++ b/feature/book_details/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.bookdetails"
     }
 

--- a/feature/books/build.gradle.kts
+++ b/feature/books/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.books"
     }
 

--- a/feature/congrats/build.gradle.kts
+++ b/feature/congrats/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.congrats"
     }
 

--- a/feature/day/build.gradle.kts
+++ b/feature/day/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.day"
     }
 

--- a/feature/delete_notes/build.gradle.kts
+++ b/feature/delete_notes/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.deletenotes"
     }
 

--- a/feature/delete_progress/build.gradle.kts
+++ b/feature/delete_progress/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.deleteprogress"
     }
 

--- a/feature/delete_version/build.gradle.kts
+++ b/feature/delete_version/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.deleteversion"
     }
 

--- a/feature/donation/build.gradle.kts
+++ b/feature/donation/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.donation"
     }
 

--- a/feature/donation/pix_qr/build.gradle.kts
+++ b/feature/donation/pix_qr/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.donation.pixqr"
     }
 

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.login"
     }
 

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.main"
     }
 

--- a/feature/material_you/build.gradle.kts
+++ b/feature/material_you/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.materialyou"
     }
 

--- a/feature/more/build.gradle.kts
+++ b/feature/more/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.more"
     }
 

--- a/feature/notification_permission/build.gradle.kts
+++ b/feature/notification_permission/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.notificationpermission"
     }
 

--- a/feature/paywall/build.gradle.kts
+++ b/feature/paywall/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.paywall"
     }
 

--- a/feature/preferences/app_language/build.gradle.kts
+++ b/feature/preferences/app_language/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.applanguage"
     }
 

--- a/feature/preferences/bible_version/build.gradle.kts
+++ b/feature/preferences/bible_version/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.bibleversion"
     }
 

--- a/feature/preferences/edit_plan_start_date/build.gradle.kts
+++ b/feature/preferences/edit_plan_start_date/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.editplanstartdate"
     }
 

--- a/feature/preferences/theme_selection/build.gradle.kts
+++ b/feature/preferences/theme_selection/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.themeselection"
     }
 

--- a/feature/read/build.gradle.kts
+++ b/feature/read/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.read"
     }
 

--- a/feature/reading_plan/build.gradle.kts
+++ b/feature/reading_plan/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.readingplan"
     }
     jvm()

--- a/feature/release_notes/build.gradle.kts
+++ b/feature/release_notes/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.release_notes"
     }
 

--- a/feature/subscription-details/build.gradle.kts
+++ b/feature/subscription-details/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.feature.subscriptiondetails"
     }
 

--- a/ui/component/build.gradle.kts
+++ b/ui/component/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.ui.component"
     }
 

--- a/ui/theme/build.gradle.kts
+++ b/ui/theme/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.ui.theme"
     }
 

--- a/ui/utils/build.gradle.kts
+++ b/ui/utils/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.quare.bibleplanner.ui.utils"
     }
 


### PR DESCRIPTION
The Kotlin Multiplatform Gradle DSL deprecated the `androidLibrary` block in favor of `android`. All 46 module `build.gradle.kts` files were updated to use the new `android` block, eliminating the deprecation warning across the entire project. No functional changes — this is a pure build configuration update.