### PR TITLE
fix: run release lanes from the repo root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       branch: ${{ steps.resolve.outputs.branch }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -83,7 +83,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 1
@@ -132,7 +132,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 1
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -49,6 +49,9 @@ flowchart TD
      uploads it to the track as a draft you release manually from the Play Console.
    - **submit_ios_for_review** — `true` (default) submits the iOS build for App Store review;
      `false` only uploads it to App Store Connect / TestFlight (use it for test runs).
+
+Alternatively, run `./scripts/release.sh` from the terminal — it asks for the same inputs as a
+menu (with the same defaults) and prints the link to the dispatched run.
 4. Click **Run workflow**.
 5. The `plan` job runs and prints the resolved version in the run summary. The run then pauses
    on the **Production** environment.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,6 +102,9 @@ platform :android do
   desc "Build a signed release AAB and upload it to Google Play"
   desc "Options: track (production|beta|alpha|internal) — defaults to production"
   lane :release do |options|
+    # fastlane runs lanes from the fastlane/ directory — operate from the repo root.
+    Dir.chdir("..")
+
     track = options[:track] || "production"
 
     # Release signing is wired in androidApp/build.gradle.kts and reads the
@@ -146,6 +149,9 @@ end
 platform :ios do
   desc "Build a signed release IPA and upload it to App Store Connect"
   lane :release do
+    # fastlane runs lanes from the fastlane/ directory — operate from the repo root.
+    Dir.chdir("..")
+
     # Creates an isolated temporary keychain on CI so signing never touches
     # the machine's login keychain. No-op when running outside CI.
     setup_ci

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Trigger the Bible Planner release workflow from the terminal — no GitHub UI.
+#
+# Shows a menu for each workflow input (defaults match the GitHub UI),
+# dispatches the `release` workflow and prints the link to the new run.
+#
+# Requires the GitHub CLI (gh), installed and authenticated:
+#   https://cli.github.com
+#
+# Usage: ./scripts/release.sh
+set -euo pipefail
+
+REPO="Quartel-Enterprise/bible-planner-mobile-client"
+WORKFLOW="release.yml"
+
+# Prints a prompt to stderr and echoes the typed answer on stdout.
+# Works in both bash and zsh (avoids the shell-specific `read -p`).
+ask() {
+  local answer
+  printf '%s' "$1" >&2
+  read -r answer
+  printf '%s' "$answer"
+}
+
+echo "Bible Planner — trigger a release"
+echo "================================="
+echo
+
+# --- version --------------------------------------------------------------
+echo "Version name (X.Y.Z). Leave blank to auto-infer from commits."
+version="$(ask 'version [auto]: ')"
+if [ -n "$version" ] && ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: version must be in X.Y.Z format (e.g. 1.14.0)." >&2
+  exit 1
+fi
+echo
+
+# --- platforms ------------------------------------------------------------
+echo "Platforms to release:"
+echo "  1) both     (default)"
+echo "  2) android"
+echo "  3) ios"
+case "$(ask 'choose [1]: ')" in
+  ""|1) platforms="both" ;;
+  2)    platforms="android" ;;
+  3)    platforms="ios" ;;
+  *)    echo "Invalid option." >&2; exit 1 ;;
+esac
+echo
+
+# --- track ----------------------------------------------------------------
+echo "Android Play Store track:"
+echo "  1) production  (default)"
+echo "  2) beta"
+echo "  3) alpha"
+echo "  4) internal"
+case "$(ask 'choose [1]: ')" in
+  ""|1) track="production" ;;
+  2)    track="beta" ;;
+  3)    track="alpha" ;;
+  4)    track="internal" ;;
+  *)    echo "Invalid option." >&2; exit 1 ;;
+esac
+echo
+
+# --- complete_android_release --------------------------------------------
+echo "Roll out the Android release? (No = upload to the track as a draft)"
+case "$(ask 'roll out? [Y/n]: ')" in
+  ""|[Yy]*) complete_android="true" ;;
+  [Nn]*)    complete_android="false" ;;
+  *)        echo "Invalid option." >&2; exit 1 ;;
+esac
+echo
+
+# --- submit_ios_for_review ------------------------------------------------
+echo "Submit the iOS build for App Store review? (No = upload to TestFlight only)"
+case "$(ask 'submit? [Y/n]: ')" in
+  ""|[Yy]*) submit_ios="true" ;;
+  [Nn]*)    submit_ios="false" ;;
+  *)        echo "Invalid option." >&2; exit 1 ;;
+esac
+echo
+
+# --- summary & confirm ----------------------------------------------------
+echo "Review:"
+echo "  version                  : ${version:-(auto-infer)}"
+echo "  platforms                : $platforms"
+echo "  track                    : $track"
+echo "  complete_android_release : $complete_android"
+echo "  submit_ios_for_review    : $submit_ios"
+echo
+case "$(ask 'Trigger this release? [y/N]: ')" in
+  [Yy]*) ;;
+  *) echo "Cancelled."; exit 0 ;;
+esac
+
+# --- dispatch -------------------------------------------------------------
+before="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json databaseId --jq '.[0].databaseId // 0')"
+
+gh workflow run "$WORKFLOW" --repo "$REPO" \
+  -f version="$version" \
+  -f platforms="$platforms" \
+  -f track="$track" \
+  -f complete_android_release="$complete_android" \
+  -f submit_ios_for_review="$submit_ios"
+
+echo
+echo "Workflow dispatched. Locating the run..."
+
+# --- find the new run and print its link ----------------------------------
+url=""
+for _ in $(seq 1 20); do
+  sleep 3
+  id="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+  if [ -n "$id" ] && [ "$id" != "$before" ]; then
+    url="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json url --jq '.[0].url')"
+    break
+  fi
+done
+
+echo
+if [ -n "$url" ]; then
+  echo "Run: $url"
+else
+  echo "Dispatched. See: https://github.com/$REPO/actions/workflows/$WORKFLOW"
+fi


### PR DESCRIPTION
## Summary

Fixes the first release run failure and adds two related improvements.

### Fix — release lanes run from the repo root

The first release run failed in the Android job:

```
Error in your Fastfile at line 115
 => 115:  props = File.read("gradle.properties")
No such file or directory @ rb_sysopen - gradle.properties
```

fastlane executes lanes with the working directory set to `fastlane/`, but the lanes use
repo-root-relative paths (`gradle.properties`, the Xcode project, the release notes JSON, the
AAB output). Each release lane now changes to the repo root (`Dir.chdir("..")`) before running.

### actions/checkout bumped to v5

Resolves the Node.js 20 deprecation warning for `actions/checkout` in the release workflow.

### scripts/release.sh

A terminal helper to trigger the release workflow without the GitHub UI. It prompts for each
input as a menu (defaults matching the UI) and prints the link to the dispatched run.

## Not included

The `actions/setup-java` / `gradle/actions/setup-gradle` Node.js 20 warnings come from the
shared `.github/actions/gradle` composite (also used by `static-analysis.yml`) and involve a
two-major `gradle/actions` jump — handled in a separate, dedicated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)