### PR TITLE
chore: upgrade CI actions to Node 24 versions

### DIFF
--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -10,7 +10,7 @@ runs:
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Make gradlew executable
       shell: bash

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -4,15 +4,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-      with:
-        gradle-home-cache-cleanup: true
+      uses: gradle/actions/setup-gradle@v5
 
     - name: Make gradlew executable
       shell: bash

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

GitHub Actions runners are dropping Node.js 20 (forced to Node 24 on June 2nd, 2026). The
release run surfaced deprecation warnings for the actions used by CI. This bumps them to the
Node 24 versions.

## Changes

- **`actions/setup-java`** `v4` → `v5` (`.github/actions/gradle`)
- **`gradle/actions/setup-gradle`** `v4` → `v6` (`.github/actions/gradle`)
- **`actions/checkout`** `v4` → `v5` (`static-analysis.yml`; the release workflow was already
  bumped in #131)
- Drops the deprecated **`gradle-home-cache-cleanup`** input — cache cleanup has been enabled
  by default since `setup-gradle@v4`.

## Note on gradle/actions v6

`gradle/actions@v6` moves the caching functionality into a separate `gradle-actions-caching`
component governed by Gradle's commercial Terms of Use. Upgrading accepts those terms — done
deliberately for this project. Enhanced Caching is free for public repositories.

## Scope

The `.github/actions/gradle` composite is shared with `static-analysis.yml`, so this also
clears that workflow's warnings. Because this PR edits `static-analysis.yml`, its own
`static-analysis` check runs the upgraded actions — validating them before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)