### PR TITLE
chore: split build and upload into separate jobs for both platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,8 @@ jobs:
         id: resolve
         run: ./scripts/suggest-version.sh "${{ inputs.version }}"
 
-  android:
-    name: Android — Google Play
+  android-build:
+    name: Android — build the AAB
     needs: plan
     if: ${{ inputs.platforms == 'both' || inputs.platforms == 'android' }}
     runs-on: ubuntu-latest
@@ -102,25 +102,70 @@ jobs:
       - name: Install fastlane
         run: gem install fastlane --no-document
 
-      - name: Decode signing and config secrets
+      - name: Decode signing and build secrets
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
         run: |
           echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.jks"
           echo "$GOOGLE_SERVICES_JSON" | base64 --decode > androidApp/google-services.json
-          printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-service-account.json"
           printf '%s\n' "$LOCAL_PROPERTIES" > local.properties
 
-      - name: Build and upload to Google Play
-        run: fastlane android release track:"${{ inputs.track }}"
+      - name: Build the signed AAB
+        run: fastlane android build
         env:
           ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      - name: Upload the AAB as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab
+          path: androidApp/build/outputs/bundle/release/
+          retention-days: 5
+          if-no-files-found: error
+
+  android-upload:
+    name: Android — upload to Google Play
+    needs: [plan, android-build]
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'android' }}
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Bump version
+        run: ./scripts/bump-version.sh "${{ needs.plan.outputs.version }}" "${{ needs.plan.outputs.version_code }}"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --no-document
+
+      - name: Decode the Play Store service account
+        env:
+          PLAY_STORE_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: printf '%s' "$PLAY_STORE_SERVICE_ACCOUNT_JSON" > "$RUNNER_TEMP/play-service-account.json"
+
+      - name: Download the AAB build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-aab
+          path: androidApp/build/outputs/bundle/release/
+
+      - name: Upload to Google Play
+        run: fastlane android upload track:"${{ inputs.track }}"
+        env:
           PLAY_STORE_JSON_KEY_PATH: ${{ runner.temp }}/play-service-account.json
           COMPLETE_RELEASE: ${{ inputs.complete_android_release }}
 
@@ -230,7 +275,7 @@ jobs:
 
   finalize:
     name: Tag, release notes and merge-back
-    needs: [plan, android, ios-upload]
+    needs: [plan, android-upload, ios-upload]
     if: ${{ inputs.platforms == 'both' && inputs.track == 'production' }}
     runs-on: ubuntu-latest
     steps:
@@ -266,7 +311,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${{ needs.plan.outputs.version }}" \
+          gh release create "${{ needs.plan.outputs.version }}" \
             --target main \
-            --title "v${{ needs.plan.outputs.version }}" \
+            --title "${{ needs.plan.outputs.version }}" \
             --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,8 @@ jobs:
           PLAY_STORE_JSON_KEY_PATH: ${{ runner.temp }}/play-service-account.json
           COMPLETE_RELEASE: ${{ inputs.complete_android_release }}
 
-  ios:
-    name: iOS — App Store Connect
+  ios-build:
+    name: iOS — build the IPA
     needs: plan
     if: ${{ inputs.platforms == 'both' || inputs.platforms == 'ios' }}
     runs-on: macos-latest
@@ -173,19 +173,64 @@ jobs:
           echo "$GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > iosApp/iosApp/GoogleService-Info.plist
           printf '%s\n' "$LOCAL_PROPERTIES" > local.properties
 
-      - name: Build and upload to App Store Connect
-        run: fastlane ios release
+      - name: Build the signed IPA
+        run: fastlane ios build
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           GIT_SSH_COMMAND: ssh -i ${{ runner.temp }}/match_ci_ssh -o IdentitiesOnly=yes
+
+      - name: Upload the IPA as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: build/ios/
+          retention-days: 5
+          if-no-files-found: error
+
+  ios-upload:
+    name: iOS — upload to App Store Connect
+    needs: [plan, ios-build]
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'ios' }}
+    runs-on: macos-latest
+    environment: Production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Bump version
+        run: ./scripts/bump-version.sh "${{ needs.plan.outputs.version }}" "${{ needs.plan.outputs.version_code }}"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --no-document
+
+      - name: Download the IPA build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-ipa
+          path: build/ios/
+
+      - name: Upload to App Store Connect
+        run: fastlane ios upload
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
 
   finalize:
     name: Tag, release notes and merge-back
-    needs: [plan, android, ios]
+    needs: [plan, android, ios-upload]
     if: ${{ inputs.platforms == 'both' && inputs.track == 'production' }}
     runs-on: ubuntu-latest
     steps:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -32,13 +32,14 @@ flowchart TD
 | Job | Runner | Gated | What it does |
 |-----|--------|-------|--------------|
 | `plan` | ubuntu | no | Resolves the version and shows it in the run summary |
-| `android` | ubuntu | yes | Builds the signed AAB and uploads it to Google Play |
+| `android-build` | ubuntu | yes | Builds the signed AAB and saves it as a build artifact |
+| `android-upload` | ubuntu | yes | Uploads the AAB to Google Play |
 | `ios-build` | macOS | yes | Builds the signed IPA and saves it as a build artifact |
 | `ios-upload` | macOS | yes | Uploads the IPA to App Store Connect and submits it for review |
 | `finalize` | ubuntu | no | Branch + version bump, merge-back PR, GitHub Release |
 
-Splitting iOS into `ios-build` and `ios-upload` means a failed upload can be retried (re-run
-just `ios-upload`) without paying for another iOS build.
+Both platforms split build and upload into separate jobs, so a failed upload can be retried
+(re-run just the `*-upload` job) without paying for another build.
 
 ## Triggering a release
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,8 +33,12 @@ flowchart TD
 |-----|--------|-------|--------------|
 | `plan` | ubuntu | no | Resolves the version and shows it in the run summary |
 | `android` | ubuntu | yes | Builds the signed AAB and uploads it to Google Play |
-| `ios` | macOS | yes | Builds the signed IPA, uploads it and submits it for App Store review |
+| `ios-build` | macOS | yes | Builds the signed IPA and saves it as a build artifact |
+| `ios-upload` | macOS | yes | Uploads the IPA to App Store Connect and submits it for review |
 | `finalize` | ubuntu | no | Branch + version bump, merge-back PR, GitHub Release |
+
+Splitting iOS into `ios-build` and `ios-upload` means a failed upload can be retried (re-run
+just `ios-upload`) without paying for another iOS build.
 
 ## Triggering a release
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -146,8 +146,8 @@ end
 # iOS
 # ---------------------------------------------------------------------------
 platform :ios do
-  desc "Build a signed release IPA and upload it to App Store Connect"
-  lane :release do
+  desc "Build the signed release IPA (no upload) — see the `upload` lane"
+  lane :build do
     # fastlane runs the lane from fastlane/; the repo root is its parent.
     repo_root = File.expand_path("..")
 
@@ -194,11 +194,15 @@ platform :ios do
       build_configurations: ["Release"],
     )
 
+    # The IPA is written to build/ios/ so the workflow can hand it to the
+    # `upload` lane (a separate job), so a failed upload never costs a rebuild.
     build_app(
       project: File.join(repo_root, XCODE_PROJECT),
       scheme: "iosApp",
       configuration: "Release",
       export_method: "app-store",
+      output_directory: File.join(repo_root, "build/ios"),
+      output_name: "BiblePlanner",
       export_options: {
         signingStyle: "manual",
         provisioningProfiles: {
@@ -206,6 +210,20 @@ platform :ios do
           WIDGET_BUNDLE_ID => "match AppStore #{WIDGET_BUNDLE_ID}",
         },
       },
+    )
+  end
+
+  desc "Upload an already-built IPA (from the `build` lane) to App Store Connect"
+  lane :upload do
+    # fastlane runs the lane from fastlane/; the repo root is its parent.
+    repo_root = File.expand_path("..")
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id: ENV.fetch("APP_STORE_CONNECT_API_ISSUER_ID"),
+      key_content: ENV.fetch("APP_STORE_CONNECT_API_KEY_P8"),
+      is_key_content_base64: true,
+      set_spaceship_token: true,
     )
 
     # Build the App Store "What's New" from the in-app release notes JSON.
@@ -217,10 +235,6 @@ platform :ios do
       UI.error("Could not prepare release notes, continuing without them: #{e.message}")
     end
 
-    # Uploads the build to App Store Connect. When SUBMIT_FOR_REVIEW is true the
-    # build is also submitted for Apple review and auto-released once approved;
-    # when false it only lands in App Store Connect / TestFlight (safe for test
-    # runs). Apple review can still reject — ship a fix as a new version.
     # Submitting for review needs a valid "What's New". If the release notes
     # could not be staged, upload the build without submitting so the run does
     # not hard-fail — finish the submission from App Store Connect.
@@ -230,8 +244,13 @@ platform :ios do
       UI.important("No release notes staged — uploading the build without submitting it for review.")
     end
 
+    # The IPA was produced by the `build` lane and restored from the build
+    # artifact into build/ios/. When SUBMIT_FOR_REVIEW is true and notes are
+    # present, the build is submitted for Apple review and auto-released once
+    # approved; otherwise it only lands in App Store Connect / TestFlight.
     upload_to_app_store(
       api_key: api_key,
+      ipa: File.join(repo_root, "build/ios/BiblePlanner.ipa"),
       metadata_path: File.join(repo_root, "fastlane/metadata"),
       skip_metadata: !has_release_notes,
       skip_screenshots: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,18 +98,23 @@ end
 # Android
 # ---------------------------------------------------------------------------
 platform :android do
-  desc "Build a signed release AAB and upload it to Google Play"
-  desc "Options: track (production|beta|alpha|internal) — defaults to production"
-  lane :release do |options|
-    # fastlane runs the lane from fastlane/; the repo root is its parent.
-    repo_root = File.expand_path("..")
-    track = options[:track] || "production"
-
+  desc "Build the signed release AAB (no upload) — see the `upload` lane"
+  lane :build do
     # Release signing is wired in androidApp/build.gradle.kts and reads the
     # ANDROID_KEYSTORE_* environment variables exported by the workflow.
+    # The AAB is written to androidApp/build/outputs/bundle/release/ and the
+    # workflow hands it to the `upload` lane (a separate job).
     gradle(
       task: ":androidApp:bundleRelease",
     )
+  end
+
+  desc "Upload an already-built AAB (from the `build` lane) to Google Play"
+  desc "Options: track (production|beta|alpha|internal) — defaults to production"
+  lane :upload do |options|
+    # fastlane runs the lane from fastlane/; the repo root is its parent.
+    repo_root = File.expand_path("..")
+    track = options[:track] || "production"
 
     # Build the Play "What's new" from the in-app release notes JSON, keyed by
     # the version currently set in gradle.properties. Non-fatal on failure.

--- a/scripts/suggest-version.sh
+++ b/scripts/suggest-version.sh
@@ -47,8 +47,8 @@ elif [[ -n "$json_version" ]] && is_higher "$json_version" "$current_version"; t
   version="$json_version"
   source_desc="taken from the release notes JSON (the team's declared next version)"
 else
-  # Anchor = last v* tag, falling back to the last "merge back" commit.
-  anchor="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+  # Anchor = last X.Y.Z tag, falling back to the last "merge back" commit.
+  anchor="$(git describe --tags --abbrev=0 --match '[0-9]*' 2>/dev/null || true)"
   if [[ -z "$anchor" ]]; then
     anchor="$(git log --grep='merge back' --format='%H' -n 1 2>/dev/null || true)"
   fi


### PR DESCRIPTION
## Summary

Splits the release of each platform into a **build** job and an **upload** job,
so a failed upload can be retried by re-running just the upload — no rebuild.

- **`android-build`** → `gradle bundleRelease`, saves the AAB as the `android-aab` artifact.
- **`android-upload`** → downloads the AAB, uploads it to Google Play.
- **`ios-build`** → match + `build_app`, saves the IPA as the `ios-ipa` artifact.
- **`ios-upload`** → downloads the IPA, uploads it to App Store Connect.

The Fastlane lanes are likewise split into `android build` / `android upload` and
`ios build` / `ios upload`.

## Also

Drops the leading `v` from the GitHub release tag created by `finalize`, to match
the existing `1.13.0` / `1.12.0` tags. `suggest-version.sh` now matches the
`X.Y.Z` tag format.

## Notes

- All four build/upload jobs use the `Production` environment, so the run pauses
  for approval at the build stage and again at the upload stage.
- `finalize` now depends on `android-upload` and `ios-upload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)