### PR TITLE
fix: align landscape weeks column with side panel in reading plan

### DIFF
--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/content/ReadingPlanContent.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/content/ReadingPlanContent.kt
@@ -67,6 +67,7 @@ internal fun ReadingPlanScreen(
                 sharedTransitionScope = sharedTransitionScope,
                 animatedContentScope = animatedContentScope,
                 onEvent = onEvent,
+                modifier = Modifier.padding(top = 16.dp),
             )
         },
     )

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
@@ -2,7 +2,8 @@
   "1.15.0": [
     "The reading plan screen now uses a two-column layout on tablets and larger displays, with the progress panel on the left and the weeks list on the right, both scrollable independently across the full screen.",
     "Today's reading is now highlighted in the day list, making it easier to find where you should be.",
-    "Smoother response when marking days as read in the reading plan, especially on older devices."
+    "Smoother response when marking days as read in the reading plan, especially on older devices.",
+    "Improved vertical alignment between the progress panel and the weeks list in the new two-column reading plan layout."
   ],
   "1.14.0": [
     "When changing the app language, the current language now appears highlighted at the top of the list, with the rest sorted alphabetically."

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
@@ -2,7 +2,8 @@
   "1.15.0": [
     "La pantalla del plan de lectura ahora usa un diseño de dos columnas en tabletas y pantallas más grandes, con el panel de progreso a la izquierda y la lista de semanas a la derecha, ambos con desplazamiento independiente en todo el ancho de la pantalla.",
     "La lectura de hoy ahora aparece destacada en la lista de días, facilitando encontrar dónde debes estar.",
-    "Respuesta más fluida al marcar días como leídos en el plan de lectura, especialmente en dispositivos más antiguos."
+    "Respuesta más fluida al marcar días como leídos en el plan de lectura, especialmente en dispositivos más antiguos.",
+    "Mejor alineación vertical entre el panel de progreso y la lista de semanas en el nuevo diseño de dos columnas del plan de lectura."
   ],
   "1.14.0": [
     "Al cambiar el idioma de la aplicación, el idioma actual ahora aparece destacado en la parte superior de la lista, con los demás en orden alfabético."

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
@@ -2,7 +2,8 @@
   "1.15.0": [
     "A tela do plano de leitura agora usa um layout em duas colunas em tablets e telas maiores, com o painel de progresso à esquerda e a lista de semanas à direita, ambos com rolagem independente em toda a largura da tela.",
     "A leitura de hoje agora aparece destacada na lista de dias, facilitando encontrar onde você deve estar.",
-    "Resposta mais fluida ao marcar dias como lidos no plano de leitura, principalmente em aparelhos mais antigos."
+    "Resposta mais fluida ao marcar dias como lidos no plano de leitura, principalmente em aparelhos mais antigos.",
+    "Melhor alinhamento vertical entre o painel de progresso e a lista de semanas no novo layout de duas colunas do plano de leitura."
   ],
   "1.14.0": [
     "Ao trocar o idioma do aplicativo, o idioma atual aparece em destaque no topo da lista, com os demais em ordem alfabética."


### PR DESCRIPTION
The reading plan's two-column landscape layout had a small visual alignment issue: the weeks list on the right started at the very top of its column, while the left side panel content (segmented buttons + progress) sat below natural vertical padding. This made the right column look noticeably higher than the left.

Added a 16.dp top padding to the `weeksItems` slot in the landscape right column of `ReadingPlanScreen` so both columns visually start at the same baseline.

No release notes update — version 1.15.0 (which introduces the two-column layout) hasn't shipped yet, so this is pre-release polish on an unreleased feature.