### PR TITLE
refactor: group release scripts and extract shared dispatch helper

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -55,8 +55,9 @@ Both platforms split build and upload into separate jobs, so a failed upload can
    - **submit_ios_for_review** — `true` (default) submits the iOS build for App Store review;
      `false` only uploads it to App Store Connect / TestFlight (use it for test runs).
 
-Alternatively, run `./scripts/release.sh` from the terminal — it asks for the same inputs as a
-menu (with the same defaults) and prints the link to the dispatched run.
+Alternatively, run `./scripts/release/release.sh` from the terminal — it asks for the same inputs
+as a menu (with the same defaults) and prints the link to the dispatched run. For a full
+production release on both stores with no prompts, run `./scripts/release/release-prod.sh`.
 4. Click **Run workflow**.
 5. The `plan` job runs and prints the resolved version in the run summary. The run then pauses
    on the **Production** environment.

--- a/scripts/release/_common.sh
+++ b/scripts/release/_common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the release scripts in this directory.
+# Sourced — not executed directly.
+
+REPO="Quartel-Enterprise/bible-planner-mobile-client"
+WORKFLOW="release.yml"
+
+# Dispatches the release workflow with the given inputs, then waits for the
+# new run to appear and prints its URL.
+#
+# Args: version platforms track complete_android_release submit_ios_for_review
+dispatch_release() {
+  local version="$1"
+  local platforms="$2"
+  local track="$3"
+  local complete_android="$4"
+  local submit_ios="$5"
+
+  local before
+  before="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json databaseId --jq '.[0].databaseId // 0')"
+
+  gh workflow run "$WORKFLOW" --repo "$REPO" \
+    -f version="$version" \
+    -f platforms="$platforms" \
+    -f track="$track" \
+    -f complete_android_release="$complete_android" \
+    -f submit_ios_for_review="$submit_ios"
+
+  echo
+  echo "Workflow dispatched. Locating the run..."
+
+  local url=""
+  local id
+  for _ in $(seq 1 20); do
+    sleep 3
+    id="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+    if [ -n "$id" ] && [ "$id" != "$before" ]; then
+      url="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json url --jq '.[0].url')"
+      break
+    fi
+  done
+
+  echo
+  if [ -n "$url" ]; then
+    echo "Run: $url"
+  else
+    echo "Dispatched. See: https://github.com/$REPO/actions/workflows/$WORKFLOW"
+  fi
+}

--- a/scripts/release/release-prod.sh
+++ b/scripts/release/release-prod.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Trigger the Bible Planner release workflow for a full production release
+# on both stores — no prompts, no menu.
+#
+# Version is auto-inferred from commits. Android rolls out to production,
+# iOS is submitted for App Store review.
+#
+# Requires the GitHub CLI (gh), installed and authenticated:
+#   https://cli.github.com
+#
+# Usage: ./scripts/release/release-prod.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_common.sh
+source "$SCRIPT_DIR/_common.sh"
+
+echo "Bible Planner — production release (android + ios)"
+echo "=================================================="
+
+dispatch_release "" "both" "production" "true" "true"

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -8,11 +8,12 @@
 # Requires the GitHub CLI (gh), installed and authenticated:
 #   https://cli.github.com
 #
-# Usage: ./scripts/release.sh
+# Usage: ./scripts/release/release.sh
 set -euo pipefail
 
-REPO="Quartel-Enterprise/bible-planner-mobile-client"
-WORKFLOW="release.yml"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_common.sh
+source "$SCRIPT_DIR/_common.sh"
 
 # Prints a prompt to stderr and echoes the typed answer on stdout.
 # Works in both bash and zsh (avoids the shell-specific `read -p`).
@@ -95,33 +96,4 @@ case "$(ask 'Trigger this release? [y/N]: ')" in
   *) echo "Cancelled."; exit 0 ;;
 esac
 
-# --- dispatch -------------------------------------------------------------
-before="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json databaseId --jq '.[0].databaseId // 0')"
-
-gh workflow run "$WORKFLOW" --repo "$REPO" \
-  -f version="$version" \
-  -f platforms="$platforms" \
-  -f track="$track" \
-  -f complete_android_release="$complete_android" \
-  -f submit_ios_for_review="$submit_ios"
-
-echo
-echo "Workflow dispatched. Locating the run..."
-
-# --- find the new run and print its link ----------------------------------
-url=""
-for _ in $(seq 1 20); do
-  sleep 3
-  id="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-  if [ -n "$id" ] && [ "$id" != "$before" ]; then
-    url="$(gh run list --workflow="$WORKFLOW" --repo "$REPO" --limit 1 --json url --jq '.[0].url')"
-    break
-  fi
-done
-
-echo
-if [ -n "$url" ]; then
-  echo "Run: $url"
-else
-  echo "Dispatched. See: https://github.com/$REPO/actions/workflows/$WORKFLOW"
-fi
+dispatch_release "$version" "$platforms" "$track" "$complete_android" "$submit_ios"


### PR DESCRIPTION
Reorganizes the terminal release scripts into a dedicated `scripts/release/` directory and removes the duplication between the interactive and direct-production variants.

- Moved `scripts/release.sh` and `scripts/release-prod.sh` into `scripts/release/`.
- Added `scripts/release/_common.sh` exposing a `dispatch_release` helper that owns the `gh workflow run` call, the `databaseId` polling and the run URL printing.
- Both entry-point scripts now source the helper and just collect/pass inputs — the interactive one keeps its menu, the prod one stays a one-liner.
- Updated `docs/release-process.md` to point at the new paths and mention the no-prompt prod variant.

No behavioral change to either script.