### PR TITLE
feature: adaptive motivation message in plan progress card

### DIFF
--- a/core/date/src/commonMain/kotlin/com/quare/bibleplanner/core/date/CurrentTimestampProvider.kt
+++ b/core/date/src/commonMain/kotlin/com/quare/bibleplanner/core/date/CurrentTimestampProvider.kt
@@ -2,6 +2,10 @@ package com.quare.bibleplanner.core.date
 
 import kotlin.time.Clock
 
-class CurrentTimestampProvider {
-    fun getCurrentTimestamp(): Long = Clock.System.now().toEpochMilliseconds()
+fun interface CurrentTimestampProvider {
+    fun getCurrentTimestamp(): Long
+}
+
+internal class CurrentTimestampProviderImpl : CurrentTimestampProvider {
+    override fun getCurrentTimestamp(): Long = Clock.System.now().toEpochMilliseconds()
 }

--- a/core/date/src/commonMain/kotlin/com/quare/bibleplanner/core/date/LocalDateTimeProvider.kt
+++ b/core/date/src/commonMain/kotlin/com/quare/bibleplanner/core/date/LocalDateTimeProvider.kt
@@ -5,10 +5,14 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
 
-class LocalDateTimeProvider {
+fun interface LocalDateTimeProvider {
+    fun getLocalDateTime(timestamp: Long): LocalDateTime
+}
+
+internal class LocalDateTimeProviderImpl : LocalDateTimeProvider {
     private val timeZone: TimeZone = TimeZone.currentSystemDefault()
 
-    fun getLocalDateTime(timestamp: Long): LocalDateTime = Instant
+    override fun getLocalDateTime(timestamp: Long): LocalDateTime = Instant
         .fromEpochMilliseconds(timestamp)
         .toLocalDateTime(timeZone)
 }

--- a/core/date/src/commonMain/kotlin/com/quare/bibleplanner/core/date/di/DateModule.kt
+++ b/core/date/src/commonMain/kotlin/com/quare/bibleplanner/core/date/di/DateModule.kt
@@ -1,13 +1,16 @@
 package com.quare.bibleplanner.core.date.di
 
 import com.quare.bibleplanner.core.date.CurrentTimestampProvider
+import com.quare.bibleplanner.core.date.CurrentTimestampProviderImpl
 import com.quare.bibleplanner.core.date.GetFinalTimestampAfterEditionUseCase
 import com.quare.bibleplanner.core.date.LocalDateTimeProvider
+import com.quare.bibleplanner.core.date.LocalDateTimeProviderImpl
 import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val dateModule = module {
-    factoryOf(::LocalDateTimeProvider)
-    factoryOf(::CurrentTimestampProvider)
+    factoryOf(::LocalDateTimeProviderImpl).bind<LocalDateTimeProvider>()
+    factoryOf(::CurrentTimestampProviderImpl).bind<CurrentTimestampProvider>()
     factoryOf(::GetFinalTimestampAfterEditionUseCase)
 }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -23,5 +23,8 @@ kotlin {
             implementation(project.dependencies.platform(libs.koinBom))
             implementation(libs.koinCore)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }

--- a/core/model/src/commonMain/kotlin/com/quare/bibleplanner/core/model/book/BookIdTestamentExtensions.kt
+++ b/core/model/src/commonMain/kotlin/com/quare/bibleplanner/core/model/book/BookIdTestamentExtensions.kt
@@ -1,0 +1,5 @@
+package com.quare.bibleplanner.core.model.book
+
+fun BookId.isNewTestament(): Boolean = ordinal >= BookId.MAT.ordinal
+
+fun BookId.isOldTestament(): Boolean = !isNewTestament()

--- a/core/model/src/commonTest/kotlin/com/quare/bibleplanner/core/model/book/BookIdTestamentExtensionsTest.kt
+++ b/core/model/src/commonTest/kotlin/com/quare/bibleplanner/core/model/book/BookIdTestamentExtensionsTest.kt
@@ -1,0 +1,141 @@
+package com.quare.bibleplanner.core.model.book
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class BookIdTestamentExtensionsTest {
+    private val oldTestamentBooks: List<BookId> = listOf(
+        BookId.GEN,
+        BookId.EXO,
+        BookId.LEV,
+        BookId.NUM,
+        BookId.DEU,
+        BookId.JOS,
+        BookId.JDG,
+        BookId.RUT,
+        BookId.FIRST_SA,
+        BookId.SECOND_SA,
+        BookId.FIRST_KI,
+        BookId.SECOND_KI,
+        BookId.FIRST_CH,
+        BookId.SECOND_CH,
+        BookId.EZR,
+        BookId.NEH,
+        BookId.EST,
+        BookId.JOB,
+        BookId.PSA,
+        BookId.PRO,
+        BookId.ECC,
+        BookId.SNG,
+        BookId.ISA,
+        BookId.JER,
+        BookId.LAM,
+        BookId.EZK,
+        BookId.DAN,
+        BookId.HOS,
+        BookId.JOL,
+        BookId.AMO,
+        BookId.OBA,
+        BookId.JON,
+        BookId.MIC,
+        BookId.NAM,
+        BookId.HAB,
+        BookId.ZEP,
+        BookId.HAG,
+        BookId.ZEC,
+        BookId.MAL,
+    )
+
+    private val newTestamentBooks: List<BookId> = listOf(
+        BookId.MAT,
+        BookId.MRK,
+        BookId.LUK,
+        BookId.JHN,
+        BookId.ACT,
+        BookId.ROM,
+        BookId.FIRST_CO,
+        BookId.SECOND_CO,
+        BookId.GAL,
+        BookId.EPH,
+        BookId.PHP,
+        BookId.COL,
+        BookId.FIRST_TH,
+        BookId.SECOND_TH,
+        BookId.FIRST_TI,
+        BookId.SECOND_TI,
+        BookId.TIT,
+        BookId.PHM,
+        BookId.HEB,
+        BookId.JAS,
+        BookId.FIRST_PE,
+        BookId.SECOND_PE,
+        BookId.FIRST_JN,
+        BookId.SECOND_JN,
+        BookId.THIRD_JN,
+        BookId.JUD,
+        BookId.REV,
+    )
+
+    @Test
+    fun `there are 39 Old Testament books`() {
+        assertEquals(39, oldTestamentBooks.size)
+    }
+
+    @Test
+    fun `there are 27 New Testament books`() {
+        assertEquals(27, newTestamentBooks.size)
+    }
+
+    @Test
+    fun `OT and NT lists together cover every BookId`() {
+        assertEquals(BookId.entries.toSet(), (oldTestamentBooks + newTestamentBooks).toSet())
+    }
+
+    @Test
+    fun `every Old Testament book returns false for isNewTestament`() {
+        oldTestamentBooks.forEach { book ->
+            assertFalse(book.isNewTestament(), "$book should not be in the New Testament")
+        }
+    }
+
+    @Test
+    fun `every New Testament book returns true for isNewTestament`() {
+        newTestamentBooks.forEach { book ->
+            assertTrue(book.isNewTestament(), "$book should be in the New Testament")
+        }
+    }
+
+    @Test
+    fun `every Old Testament book returns true for isOldTestament`() {
+        oldTestamentBooks.forEach { book ->
+            assertTrue(book.isOldTestament(), "$book should be in the Old Testament")
+        }
+    }
+
+    @Test
+    fun `every New Testament book returns false for isOldTestament`() {
+        newTestamentBooks.forEach { book ->
+            assertFalse(book.isOldTestament(), "$book should not be in the Old Testament")
+        }
+    }
+
+    @Test
+    fun `Malachi is the last Old Testament book`() {
+        assertTrue(BookId.MAL.isOldTestament())
+        assertFalse(BookId.MAL.isNewTestament())
+    }
+
+    @Test
+    fun `Matthew is the first New Testament book`() {
+        assertTrue(BookId.MAT.isNewTestament())
+        assertFalse(BookId.MAT.isOldTestament())
+    }
+
+    @Test
+    fun `Revelation is in the New Testament`() {
+        assertTrue(BookId.REV.isNewTestament())
+        assertFalse(BookId.REV.isOldTestament())
+    }
+}

--- a/feature/reading_plan/build.gradle.kts
+++ b/feature/reading_plan/build.gradle.kts
@@ -49,5 +49,8 @@ kotlin {
             // Dates
             implementation(libs.kotlinx.datetime)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }

--- a/feature/reading_plan/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/reading_plan/src/commonMain/composeResources/values-es/strings.xml
@@ -5,8 +5,38 @@
     <string name="plan_progress_title">Progreso del plan</string>
     <string name="plan_progress_days_completed">%1$d de %2$d días</string>
     <string name="plan_progress_days_remaining">%1$d días restantes</string>
-    <string name="plan_progress_motivation_default">¡Sigue así, lo estás haciendo bien!</string>
     <string name="loading">Cargando...</string>
+
+    <string name="plan_motivation_overall_zero">Todo empieza con una página.</string>
+    <string name="plan_motivation_overall_early_start">¡Gran comienzo! El hábito está naciendo.</string>
+    <string name="plan_motivation_overall_building_solid">Estás construyendo algo sólido.</string>
+    <string name="plan_motivation_overall_approaching_third">Casi un tercio completado. ¡Sigue!</string>
+    <string name="plan_motivation_overall_past_thirty">¡Ya pasaste el 30%%! Impresionante.</string>
+    <string name="plan_motivation_overall_halfway">¡Mitad del camino recorrido!</string>
+    <string name="plan_motivation_overall_more_than_half">Más de la mitad. La constancia es tuya.</string>
+    <string name="plan_motivation_overall_three_quarters">Tres cuartos completados. No pares ahora.</string>
+    <string name="plan_motivation_overall_final_stretch">La recta final se acerca.</string>
+    <string name="plan_motivation_overall_almost_there">Casi lo logras. ¡Un último esfuerzo!</string>
+    <string name="plan_motivation_overall_completed">¡Plan completado! Qué logro.</string>
+
+    <string name="plan_motivation_streak_1">Primer día — lo más difícil ya pasó.</string>
+    <string name="plan_motivation_streak_3">3 días seguidos. El hábito está empezando.</string>
+    <string name="plan_motivation_streak_7">¡Una semana entera. Eres constante!</string>
+    <string name="plan_motivation_streak_14">¡Dos semanas sin parar. Qué disciplina!</string>
+    <string name="plan_motivation_streak_30">Un mes de fidelidad. Extraordinario.</string>
+    <string name="plan_motivation_streak_100">100 días. Esto es transformación de vida.</string>
+
+    <string name="plan_motivation_day_not_started">Hoy aún no — hay tiempo.</string>
+    <string name="plan_motivation_day_started">Empezaste el día en la Palabra.</string>
+    <string name="plan_motivation_day_completed">¡Misión del día cumplida!</string>
+    <string name="plan_motivation_day_one_overdue">Volver también es valentía.</string>
+    <string name="plan_motivation_day_multiple_overdue">Sin culpa — vuelve a tu ritmo.</string>
+
+    <string name="plan_motivation_milestone_entered_new_testament">¡Llegaste al Nuevo Testamento!</string>
+    <string name="plan_motivation_milestone_only_one_left">Solo queda %1$s.</string>
+    <string name="plan_motivation_milestone_first_book_completed">¡Primer libro completado en el plan!</string>
+    <string name="plan_motivation_milestone_book_completed">Terminaste %1$s. ¡Próximo capítulo!</string>
+
     <string name="week_number">Semana %1$d</string>
     <string name="week_progress_complete">completo</string>
     <string name="week_progress_summary">%1$d de %2$d días</string>

--- a/feature/reading_plan/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/feature/reading_plan/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -5,8 +5,38 @@
     <string name="plan_progress_title">Progresso do plano</string>
     <string name="plan_progress_days_completed">%1$d de %2$d dias</string>
     <string name="plan_progress_days_remaining">%1$d dias restantes</string>
-    <string name="plan_progress_motivation_default">Continue assim, você está indo bem!</string>
     <string name="loading">Carregando...</string>
+
+    <string name="plan_motivation_overall_zero">Tudo começa com uma página.</string>
+    <string name="plan_motivation_overall_early_start">Ótimo começo! O hábito está nascendo.</string>
+    <string name="plan_motivation_overall_building_solid">Você está construindo algo sólido.</string>
+    <string name="plan_motivation_overall_approaching_third">Quase um terço concluído. Continue!</string>
+    <string name="plan_motivation_overall_past_thirty">Você já passou de 30%%! Impressionante.</string>
+    <string name="plan_motivation_overall_halfway">Metade do caminho percorrido!</string>
+    <string name="plan_motivation_overall_more_than_half">Mais da metade. A consistência é sua.</string>
+    <string name="plan_motivation_overall_three_quarters">Três quartos concluídos. Não pare agora.</string>
+    <string name="plan_motivation_overall_final_stretch">A reta final está chegando.</string>
+    <string name="plan_motivation_overall_almost_there">Quase lá. Um último esforço!</string>
+    <string name="plan_motivation_overall_completed">Plano concluído! Que conquista.</string>
+
+    <string name="plan_motivation_streak_1">Primeiro dia — o mais difícil já passou.</string>
+    <string name="plan_motivation_streak_3">3 dias seguidos. O hábito está começando.</string>
+    <string name="plan_motivation_streak_7">Uma semana inteira. Você é constante!</string>
+    <string name="plan_motivation_streak_14">Duas semanas sem parar. Que disciplina!</string>
+    <string name="plan_motivation_streak_30">Um mês de fidelidade. Extraordinário.</string>
+    <string name="plan_motivation_streak_100">100 dias. Isso é transformação de vida.</string>
+
+    <string name="plan_motivation_day_not_started">Hoje ainda não foi — tem tempo.</string>
+    <string name="plan_motivation_day_started">Você começou o dia na Palavra.</string>
+    <string name="plan_motivation_day_completed">Missão do dia cumprida!</string>
+    <string name="plan_motivation_day_one_overdue">Recomeçar também é coragem.</string>
+    <string name="plan_motivation_day_multiple_overdue">Sem culpa — volte ao seu ritmo.</string>
+
+    <string name="plan_motivation_milestone_entered_new_testament">Você chegou ao Novo Testamento!</string>
+    <string name="plan_motivation_milestone_only_one_left">Apenas %1$s pela frente.</string>
+    <string name="plan_motivation_milestone_first_book_completed">Primeiro livro concluído no plano!</string>
+    <string name="plan_motivation_milestone_book_completed">Você terminou %1$s. Próximo capítulo!</string>
+
     <string name="week_number">Semana %1$d</string>
     <string name="week_progress_complete">completo</string>
     <string name="week_progress_summary">%1$d de %2$d dias</string>

--- a/feature/reading_plan/src/commonMain/composeResources/values/strings.xml
+++ b/feature/reading_plan/src/commonMain/composeResources/values/strings.xml
@@ -5,8 +5,38 @@
     <string name="plan_progress_title">Plan progress</string>
     <string name="plan_progress_days_completed">%1$d of %2$d days</string>
     <string name="plan_progress_days_remaining">%1$d days remaining</string>
-    <string name="plan_progress_motivation_default">Keep going, you&apos;re doing great!</string>
     <string name="loading">Loading...</string>
+
+    <string name="plan_motivation_overall_zero">Every journey starts with one page.</string>
+    <string name="plan_motivation_overall_early_start">Great start! The habit is forming.</string>
+    <string name="plan_motivation_overall_building_solid">You&apos;re building something solid.</string>
+    <string name="plan_motivation_overall_approaching_third">Almost a third done. Keep going!</string>
+    <string name="plan_motivation_overall_past_thirty">Over 30%% — impressive.</string>
+    <string name="plan_motivation_overall_halfway">Halfway there!</string>
+    <string name="plan_motivation_overall_more_than_half">Past the halfway mark. Consistency wins.</string>
+    <string name="plan_motivation_overall_three_quarters">Three quarters done. Don&apos;t stop now.</string>
+    <string name="plan_motivation_overall_final_stretch">The final stretch is near.</string>
+    <string name="plan_motivation_overall_almost_there">Almost there. One last push!</string>
+    <string name="plan_motivation_overall_completed">Plan complete! What an achievement.</string>
+
+    <string name="plan_motivation_streak_1">First day — the hardest part is over.</string>
+    <string name="plan_motivation_streak_3">3 days in a row. The habit is forming.</string>
+    <string name="plan_motivation_streak_7">A whole week. You&apos;re consistent!</string>
+    <string name="plan_motivation_streak_14">Two weeks straight. What discipline!</string>
+    <string name="plan_motivation_streak_30">A month of faithfulness. Extraordinary.</string>
+    <string name="plan_motivation_streak_100">100 days. This is life-changing.</string>
+
+    <string name="plan_motivation_day_not_started">Today hasn&apos;t happened yet — there&apos;s still time.</string>
+    <string name="plan_motivation_day_started">You started your day in the Word.</string>
+    <string name="plan_motivation_day_completed">Today&apos;s mission done!</string>
+    <string name="plan_motivation_day_one_overdue">Starting over takes courage too.</string>
+    <string name="plan_motivation_day_multiple_overdue">No guilt — get back to your rhythm.</string>
+
+    <string name="plan_motivation_milestone_entered_new_testament">You&apos;ve reached the New Testament!</string>
+    <string name="plan_motivation_milestone_only_one_left">Only %1$s left to go.</string>
+    <string name="plan_motivation_milestone_first_book_completed">First book completed in the plan!</string>
+    <string name="plan_motivation_milestone_book_completed">You finished %1$s. Next chapter!</string>
+
     <string name="week_number">Week %1$d</string>
     <string name="week_progress_complete">complete</string>
     <string name="week_progress_summary">%1$d of %2$d days</string>

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/di/ReadingPlanModule.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/di/ReadingPlanModule.kt
@@ -1,10 +1,20 @@
 package com.quare.bibleplanner.feature.readingplan.di
 
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.FindFirstWeekWithUnreadBook
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.GetPlanMotivationMessage
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.GetSelectedReadingPlanFlow
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveDaySituationMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveMilestoneMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveOverallProgressMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveStreakMotivation
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.SetSelectedReadingPlan
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.FindFirstWeekWithUnreadBookUseCase
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.GetPlanMotivationMessageUseCase
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.GetSelectedReadingPlanFlowUseCase
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.ResolveDaySituationMotivationUseCase
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.ResolveMilestoneMotivationUseCase
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.ResolveOverallProgressMotivationUseCase
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.ResolveStreakMotivationUseCase
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.impl.SetSelectedReadingPlanUseCase
 import com.quare.bibleplanner.feature.readingplan.presentation.factory.ReadingPlanStateFactory
 import com.quare.bibleplanner.feature.readingplan.presentation.mapper.CalculateIsFirstUnreadWeekVisible
@@ -23,6 +33,11 @@ val readingPlanModule = module {
     factoryOf(::GetSelectedReadingPlanFlowUseCase).bind<GetSelectedReadingPlanFlow>()
     factoryOf(::SetSelectedReadingPlanUseCase).bind<SetSelectedReadingPlan>()
     factoryOf(::FindFirstWeekWithUnreadBookUseCase).bind<FindFirstWeekWithUnreadBook>()
+    factoryOf(::ResolveMilestoneMotivationUseCase).bind<ResolveMilestoneMotivation>()
+    factoryOf(::ResolveStreakMotivationUseCase).bind<ResolveStreakMotivation>()
+    factoryOf(::ResolveDaySituationMotivationUseCase).bind<ResolveDaySituationMotivation>()
+    factoryOf(::ResolveOverallProgressMotivationUseCase).bind<ResolveOverallProgressMotivation>()
+    factoryOf(::GetPlanMotivationMessageUseCase).bind<GetPlanMotivationMessage>()
 
     // Presentation
     viewModelOf(::ReadingPlanViewModel)

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/model/PlanMotivationMessage.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/model/PlanMotivationMessage.kt
@@ -1,0 +1,69 @@
+package com.quare.bibleplanner.feature.readingplan.domain.model
+
+import com.quare.bibleplanner.core.model.book.BookId
+
+internal sealed interface PlanMotivationMessage {
+    sealed interface OverallProgress : PlanMotivationMessage {
+        data object Zero : OverallProgress
+
+        data object EarlyStart : OverallProgress
+
+        data object BuildingSolid : OverallProgress
+
+        data object ApproachingThird : OverallProgress
+
+        data object PastThirty : OverallProgress
+
+        data object Halfway : OverallProgress
+
+        data object MoreThanHalf : OverallProgress
+
+        data object ThreeQuarters : OverallProgress
+
+        data object FinalStretch : OverallProgress
+
+        data object AlmostThere : OverallProgress
+
+        data object Completed : OverallProgress
+    }
+
+    sealed interface Streak : PlanMotivationMessage {
+        data object Day1 : Streak
+
+        data object Day3 : Streak
+
+        data object Day7 : Streak
+
+        data object Day14 : Streak
+
+        data object Day30 : Streak
+
+        data object Day100 : Streak
+    }
+
+    sealed interface DaySituation : PlanMotivationMessage {
+        data object NotStarted : DaySituation
+
+        data object Started : DaySituation
+
+        data object Completed : DaySituation
+
+        data object OneOverdue : DaySituation
+
+        data object MultipleOverdue : DaySituation
+    }
+
+    sealed interface Milestone : PlanMotivationMessage {
+        data object EnteredNewTestament : Milestone
+
+        data class OnlyOneBookLeft(
+            val bookId: BookId,
+        ) : Milestone
+
+        data object FirstBookCompleted : Milestone
+
+        data class BookCompleted(
+            val bookId: BookId,
+        ) : Milestone
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/GetPlanMotivationMessage.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/GetPlanMotivationMessage.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase
+
+import com.quare.bibleplanner.core.model.plan.WeekPlanModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+
+internal fun interface GetPlanMotivationMessage {
+    operator fun invoke(
+        weeks: List<WeekPlanModel>,
+        bibleProgress: Float,
+    ): PlanMotivationMessage
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveDaySituationMotivation.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveDaySituationMotivation.kt
@@ -1,0 +1,12 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase
+
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+import kotlinx.datetime.LocalDate
+
+internal fun interface ResolveDaySituationMotivation {
+    operator fun invoke(
+        days: List<DayModel>,
+        today: LocalDate,
+    ): PlanMotivationMessage.DaySituation?
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveMilestoneMotivation.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveMilestoneMotivation.kt
@@ -1,0 +1,11 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase
+
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+
+internal fun interface ResolveMilestoneMotivation {
+    operator fun invoke(
+        days: List<DayModel>,
+        nowMillis: Long,
+    ): PlanMotivationMessage.Milestone?
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveOverallProgressMotivation.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveOverallProgressMotivation.kt
@@ -1,0 +1,7 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase
+
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+
+internal fun interface ResolveOverallProgressMotivation {
+    operator fun invoke(progress: Float): PlanMotivationMessage.OverallProgress
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveStreakMotivation.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/ResolveStreakMotivation.kt
@@ -1,0 +1,12 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase
+
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+import kotlinx.datetime.LocalDate
+
+internal fun interface ResolveStreakMotivation {
+    operator fun invoke(
+        days: List<DayModel>,
+        today: LocalDate,
+    ): PlanMotivationMessage.Streak?
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/GetPlanMotivationMessageUseCase.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/GetPlanMotivationMessageUseCase.kt
@@ -1,0 +1,34 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.date.CurrentTimestampProvider
+import com.quare.bibleplanner.core.date.LocalDateTimeProvider
+import com.quare.bibleplanner.core.model.plan.WeekPlanModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.GetPlanMotivationMessage
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveDaySituationMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveMilestoneMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveOverallProgressMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveStreakMotivation
+
+internal class GetPlanMotivationMessageUseCase(
+    private val currentTimestampProvider: CurrentTimestampProvider,
+    private val localDateTimeProvider: LocalDateTimeProvider,
+    private val resolveMilestoneMotivation: ResolveMilestoneMotivation,
+    private val resolveStreakMotivation: ResolveStreakMotivation,
+    private val resolveDaySituationMotivation: ResolveDaySituationMotivation,
+    private val resolveOverallProgressMotivation: ResolveOverallProgressMotivation,
+) : GetPlanMotivationMessage {
+    override fun invoke(
+        weeks: List<WeekPlanModel>,
+        bibleProgress: Float,
+    ): PlanMotivationMessage {
+        val nowMillis = currentTimestampProvider.getCurrentTimestamp()
+        val today = localDateTimeProvider.getLocalDateTime(nowMillis).date
+        val days = weeks.flatMap { it.days }
+
+        return resolveMilestoneMotivation(days, nowMillis)
+            ?: resolveStreakMotivation(days, today)
+            ?: resolveDaySituationMotivation(days, today)
+            ?: resolveOverallProgressMotivation(bibleProgress)
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveDaySituationMotivationUseCase.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveDaySituationMotivationUseCase.kt
@@ -1,0 +1,32 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.DaySituation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveDaySituationMotivation
+import kotlinx.datetime.LocalDate
+
+internal class ResolveDaySituationMotivationUseCase : ResolveDaySituationMotivation {
+    override fun invoke(
+        days: List<DayModel>,
+        today: LocalDate,
+    ): DaySituation? {
+        val todayDay = days.find { it.isToday }
+        val overdueCount = days.count { day ->
+            val planned = day.plannedReadDate
+            planned != null && planned < today && !day.isRead && !day.isToday
+        }
+
+        if (todayDay != null) {
+            if (todayDay.isRead) return DaySituation.Completed
+            if (todayDay.readVerses in 1 until todayDay.totalVerses) return DaySituation.Started
+        }
+
+        if (overdueCount >= 2) return DaySituation.MultipleOverdue
+        if (overdueCount == 1) return DaySituation.OneOverdue
+
+        if (todayDay != null && todayDay.totalVerses > 0 && todayDay.readVerses == 0) {
+            return DaySituation.NotStarted
+        }
+        return null
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveMilestoneMotivationUseCase.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveMilestoneMotivationUseCase.kt
@@ -1,0 +1,97 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.model.book.BookId
+import com.quare.bibleplanner.core.model.book.isNewTestament
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Milestone
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveMilestoneMotivation
+
+private const val MILESTONE_WINDOW_MILLIS: Long = 24L * 60L * 60L * 1000L
+
+internal class ResolveMilestoneMotivationUseCase : ResolveMilestoneMotivation {
+    override fun invoke(
+        days: List<DayModel>,
+        nowMillis: Long,
+    ): Milestone? {
+        val booksInPlan = days
+            .flatMap { it.passages }
+            .map { it.bookId }
+            .distinct()
+        if (booksInPlan.isEmpty()) return null
+
+        val booksWithUnreadPassages = days
+            .flatMap { it.passages }
+            .filter { !it.isRead }
+            .map { it.bookId }
+            .distinct()
+        val booksFullyRead = booksInPlan - booksWithUnreadPassages.toSet()
+
+        val mostRecentReadDay = days
+            .filter { it.readTimestamp != null }
+            .maxByOrNull { it.readTimestamp!! }
+        val isWithinWindow = mostRecentReadDay
+            ?.readTimestamp
+            ?.let { nowMillis - it <= MILESTONE_WINDOW_MILLIS } == true
+
+        resolveEnteredNewTestament(days, mostRecentReadDay, isWithinWindow)
+            ?.let { return it }
+
+        resolveOnlyOneBookLeft(booksInPlan, booksWithUnreadPassages, booksFullyRead)
+            ?.let { return it }
+
+        if (!isWithinWindow || mostRecentReadDay == null) return null
+
+        val booksClosedByMostRecentDay = mostRecentReadDay.passages
+            .map { it.bookId }
+            .distinct()
+            .filter { it in booksFullyRead }
+
+        if (booksClosedByMostRecentDay.isEmpty()) return null
+
+        if (booksFullyRead.size == 1 && booksClosedByMostRecentDay.size == 1) {
+            return Milestone.FirstBookCompleted
+        }
+
+        val closedBook = booksClosedByMostRecentDay.maxByOrNull { it.ordinal } ?: return null
+        return Milestone.BookCompleted(closedBook)
+    }
+
+    private fun resolveEnteredNewTestament(
+        days: List<DayModel>,
+        mostRecentReadDay: DayModel?,
+        isWithinWindow: Boolean,
+    ): Milestone? {
+        if (!isWithinWindow || mostRecentReadDay == null) return null
+        val mostRecentTimestamp = mostRecentReadDay.readTimestamp ?: return null
+        val recentHasNewTestament = mostRecentReadDay.passages.any { it.bookId.isNewTestament() }
+        if (!recentHasNewTestament) return null
+
+        val earlierReadDays = days
+            .filter { day ->
+                val ts = day.readTimestamp
+                ts != null && ts < mostRecentTimestamp
+            }
+        val earlierHasNewTestament = earlierReadDays.any { day ->
+            day.passages.any { it.bookId.isNewTestament() }
+        }
+        if (earlierHasNewTestament) return null
+
+        val earlierHasOldTestament = earlierReadDays.any { day ->
+            day.passages.any { !it.bookId.isNewTestament() }
+        }
+        if (!earlierHasOldTestament) return null
+
+        return Milestone.EnteredNewTestament
+    }
+
+    private fun resolveOnlyOneBookLeft(
+        booksInPlan: List<BookId>,
+        booksWithUnreadPassages: List<BookId>,
+        booksFullyRead: List<BookId>,
+    ): Milestone? {
+        if (booksInPlan.size <= 1) return null
+        if (booksWithUnreadPassages.size != 1) return null
+        if (booksFullyRead.isEmpty()) return null
+        return Milestone.OnlyOneBookLeft(booksWithUnreadPassages.single())
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveOverallProgressMotivationUseCase.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveOverallProgressMotivationUseCase.kt
@@ -1,0 +1,24 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.OverallProgress
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveOverallProgressMotivation
+import kotlin.math.roundToInt
+
+internal class ResolveOverallProgressMotivationUseCase : ResolveOverallProgressMotivation {
+    override fun invoke(progress: Float): OverallProgress {
+        val pct = progress.roundToInt().coerceIn(0, 100)
+        return when (pct) {
+            0 -> OverallProgress.Zero
+            in 1..5 -> OverallProgress.EarlyStart
+            in 6..15 -> OverallProgress.BuildingSolid
+            in 16..30 -> OverallProgress.ApproachingThird
+            in 31..49 -> OverallProgress.PastThirty
+            50 -> OverallProgress.Halfway
+            in 51..74 -> OverallProgress.MoreThanHalf
+            75 -> OverallProgress.ThreeQuarters
+            in 76..90 -> OverallProgress.FinalStretch
+            in 91..99 -> OverallProgress.AlmostThere
+            else -> OverallProgress.Completed
+        }
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveStreakMotivationUseCase.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveStreakMotivationUseCase.kt
@@ -1,0 +1,44 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.date.LocalDateTimeProvider
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Streak
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveStreakMotivation
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+
+internal class ResolveStreakMotivationUseCase(
+    private val localDateTimeProvider: LocalDateTimeProvider,
+) : ResolveStreakMotivation {
+    override fun invoke(
+        days: List<DayModel>,
+        today: LocalDate,
+    ): Streak? {
+        val readDates = days
+            .mapNotNull { it.readTimestamp }
+            .map { localDateTimeProvider.getLocalDateTime(it).date }
+            .distinct()
+            .sortedDescending()
+
+        if (readDates.firstOrNull() != today) return null
+
+        var count = 1
+        var expected = today.minus(1, DateTimeUnit.DAY)
+        for (date in readDates.drop(1)) {
+            if (date != expected) break
+            count++
+            expected = expected.minus(1, DateTimeUnit.DAY)
+        }
+
+        return when {
+            count >= 100 -> Streak.Day100
+            count >= 30 -> Streak.Day30
+            count >= 14 -> Streak.Day14
+            count >= 7 -> Streak.Day7
+            count >= 3 -> Streak.Day3
+            count >= 1 -> Streak.Day1
+            else -> null
+        }
+    }
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/PlanMotivationMessageText.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/PlanMotivationMessageText.kt
@@ -1,0 +1,102 @@
+package com.quare.bibleplanner.feature.readingplan.presentation.component
+
+import androidx.compose.runtime.Composable
+import bibleplanner.feature.reading_plan.generated.resources.Res
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_day_completed
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_day_multiple_overdue
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_day_not_started
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_day_one_overdue
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_day_started
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_milestone_book_completed
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_milestone_entered_new_testament
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_milestone_first_book_completed
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_milestone_only_one_left
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_almost_there
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_approaching_third
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_building_solid
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_completed
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_early_start
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_final_stretch
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_halfway
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_more_than_half
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_past_thirty
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_three_quarters
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_overall_zero
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_streak_1
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_streak_100
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_streak_14
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_streak_3
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_streak_30
+import bibleplanner.feature.reading_plan.generated.resources.plan_motivation_streak_7
+import com.quare.bibleplanner.core.books.util.toBookNameResource
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.DaySituation
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Milestone
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.OverallProgress
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Streak
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun PlanMotivationMessage.resolveText(): String = when (this) {
+    OverallProgress.Zero -> stringResource(Res.string.plan_motivation_overall_zero)
+
+    OverallProgress.EarlyStart -> stringResource(Res.string.plan_motivation_overall_early_start)
+
+    OverallProgress.BuildingSolid -> stringResource(Res.string.plan_motivation_overall_building_solid)
+
+    OverallProgress.ApproachingThird -> stringResource(Res.string.plan_motivation_overall_approaching_third)
+
+    OverallProgress.PastThirty -> stringResource(Res.string.plan_motivation_overall_past_thirty)
+
+    OverallProgress.Halfway -> stringResource(Res.string.plan_motivation_overall_halfway)
+
+    OverallProgress.MoreThanHalf -> stringResource(Res.string.plan_motivation_overall_more_than_half)
+
+    OverallProgress.ThreeQuarters -> stringResource(Res.string.plan_motivation_overall_three_quarters)
+
+    OverallProgress.FinalStretch -> stringResource(Res.string.plan_motivation_overall_final_stretch)
+
+    OverallProgress.AlmostThere -> stringResource(Res.string.plan_motivation_overall_almost_there)
+
+    OverallProgress.Completed -> stringResource(Res.string.plan_motivation_overall_completed)
+
+    Streak.Day1 -> stringResource(Res.string.plan_motivation_streak_1)
+
+    Streak.Day3 -> stringResource(Res.string.plan_motivation_streak_3)
+
+    Streak.Day7 -> stringResource(Res.string.plan_motivation_streak_7)
+
+    Streak.Day14 -> stringResource(Res.string.plan_motivation_streak_14)
+
+    Streak.Day30 -> stringResource(Res.string.plan_motivation_streak_30)
+
+    Streak.Day100 -> stringResource(Res.string.plan_motivation_streak_100)
+
+    DaySituation.NotStarted -> stringResource(Res.string.plan_motivation_day_not_started)
+
+    DaySituation.Started -> stringResource(Res.string.plan_motivation_day_started)
+
+    DaySituation.Completed -> stringResource(Res.string.plan_motivation_day_completed)
+
+    DaySituation.OneOverdue -> stringResource(Res.string.plan_motivation_day_one_overdue)
+
+    DaySituation.MultipleOverdue -> stringResource(Res.string.plan_motivation_day_multiple_overdue)
+
+    Milestone.EnteredNewTestament -> stringResource(
+        Res.string.plan_motivation_milestone_entered_new_testament,
+    )
+
+    is Milestone.OnlyOneBookLeft -> stringResource(
+        Res.string.plan_motivation_milestone_only_one_left,
+        stringResource(bookId.toBookNameResource()),
+    )
+
+    Milestone.FirstBookCompleted -> stringResource(
+        Res.string.plan_motivation_milestone_first_book_completed,
+    )
+
+    is Milestone.BookCompleted -> stringResource(
+        Res.string.plan_motivation_milestone_book_completed,
+        stringResource(bookId.toBookNameResource()),
+    )
+}

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/PlanProgress.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/component/PlanProgress.kt
@@ -28,19 +28,20 @@ import bibleplanner.feature.reading_plan.generated.resources.Res
 import bibleplanner.feature.reading_plan.generated.resources.loading
 import bibleplanner.feature.reading_plan.generated.resources.plan_progress_days_completed
 import bibleplanner.feature.reading_plan.generated.resources.plan_progress_days_remaining
-import bibleplanner.feature.reading_plan.generated.resources.plan_progress_motivation_default
 import bibleplanner.feature.reading_plan.generated.resources.plan_progress_title
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
 import com.quare.bibleplanner.ui.component.progress.AppLinearProgressBar
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.abs
 import kotlin.math.round
 
 @Composable
-fun PlanProgress(
+internal fun PlanProgress(
     isLoading: Boolean,
     progress: Float,
     readDaysCount: Int,
     totalDaysCount: Int,
+    motivationMessage: PlanMotivationMessage?,
     modifier: Modifier = Modifier,
 ) {
     val animatedProgress by animateFloatAsState(
@@ -78,7 +79,7 @@ fun PlanProgress(
             )
             Text(
                 modifier = Modifier.fillMaxWidth(),
-                text = stringResource(Res.string.plan_progress_motivation_default),
+                text = motivationMessage?.resolveText().orEmpty(),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Start,

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/content/ReadingPlanContent.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/content/ReadingPlanContent.kt
@@ -100,6 +100,7 @@ private fun ResponsiveContentScope.sidePanelItems(
             progress = loadedUiState?.progress ?: 0f,
             readDaysCount = readDaysCount,
             totalDaysCount = totalDaysCount,
+            motivationMessage = loadedUiState?.motivationMessage,
             isLoading = uiState is ReadingPlanUiState.Loading,
         )
     }

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/model/ReadingPlanUiState.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/model/ReadingPlanUiState.kt
@@ -1,6 +1,7 @@
 package com.quare.bibleplanner.feature.readingplan.presentation.model
 
 import com.quare.bibleplanner.core.model.plan.ReadingPlanType
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
 
 internal sealed interface ReadingPlanUiState {
     val selectedReadingPlan: ReadingPlanType
@@ -13,6 +14,7 @@ internal sealed interface ReadingPlanUiState {
     data class Loaded(
         val weekPlans: List<WeekPlanPresentationModel>,
         val progress: Float,
+        val motivationMessage: PlanMotivationMessage,
         override val selectedReadingPlan: ReadingPlanType,
         override val isShowingMenu: Boolean,
         override val scrollToWeekNumber: Int = 0,

--- a/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/viewmodel/ReadingPlanViewModel.kt
+++ b/feature/reading_plan/src/commonMain/kotlin/com/quare/bibleplanner/feature/readingplan/presentation/viewmodel/ReadingPlanViewModel.kt
@@ -9,6 +9,7 @@ import com.quare.bibleplanner.core.model.plan.WeekPlanModel
 import com.quare.bibleplanner.core.plan.domain.usecase.GetPlansByWeekUseCase
 import com.quare.bibleplanner.core.plan.domain.usecase.UpdateDayReadStatusUseCase
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.FindFirstWeekWithUnreadBook
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.GetPlanMotivationMessage
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.GetSelectedReadingPlanFlow
 import com.quare.bibleplanner.feature.readingplan.domain.usecase.SetSelectedReadingPlan
 import com.quare.bibleplanner.feature.readingplan.presentation.factory.ReadingPlanStateFactory
@@ -35,6 +36,7 @@ internal class ReadingPlanViewModel(
     calculateBibleProgress: CalculateBibleProgressUseCase,
     private val setSelectedReadingPlan: SetSelectedReadingPlan,
     private val findFirstWeekWithUnreadBook: FindFirstWeekWithUnreadBook,
+    private val getPlanMotivationMessage: GetPlanMotivationMessage,
     private val weeksPlanPresentationMapper: WeeksPlanPresentationMapper,
     private val calculateIsFirstUnreadWeekVisible: CalculateIsFirstUnreadWeekVisible,
     private val deleteProgressMapper: DeleteProgressMapper,
@@ -57,7 +59,11 @@ internal class ReadingPlanViewModel(
             _uiState.update { currentState ->
                 when (currentState) {
                     is ReadingPlanUiState.Loaded -> {
-                        currentState.copy(progress = progress)
+                        val rawWeeks = currentState.weekPlans.map { it.weekPlan }
+                        currentState.copy(
+                            progress = progress,
+                            motivationMessage = getPlanMotivationMessage(rawWeeks, progress),
+                        )
                     }
 
                     is ReadingPlanUiState.Loading -> {
@@ -78,6 +84,7 @@ internal class ReadingPlanViewModel(
                     ReadingPlanUiState.Loaded(
                         weekPlans = weekPresentationModels,
                         progress = currentBibleProgress,
+                        motivationMessage = getPlanMotivationMessage(selectedWeeks, currentBibleProgress),
                         selectedReadingPlan = selectedPlan,
                         isShowingMenu = currentState.isShowingMenu,
                         scrollToWeekNumber = currentState.scrollToWeekNumber,
@@ -130,6 +137,7 @@ internal class ReadingPlanViewModel(
                 ReadingPlanUiState.Loaded(
                     weekPlans = weekPresentationModels,
                     progress = currentBibleProgress,
+                    motivationMessage = getPlanMotivationMessage(selectedWeeks, currentBibleProgress),
                     selectedReadingPlan = selectedPlan,
                     isShowingMenu = uiState.value.isShowingMenu,
                     scrollToWeekNumber = scrollToWeekNumber,

--- a/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/GetPlanMotivationMessageUseCaseTest.kt
+++ b/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/GetPlanMotivationMessageUseCaseTest.kt
@@ -1,0 +1,163 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.date.CurrentTimestampProvider
+import com.quare.bibleplanner.core.date.LocalDateTimeProvider
+import com.quare.bibleplanner.core.model.book.BookId
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.core.model.plan.WeekPlanModel
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.DaySituation
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Milestone
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.OverallProgress
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Streak
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveDaySituationMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveMilestoneMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveOverallProgressMotivation
+import com.quare.bibleplanner.feature.readingplan.domain.usecase.ResolveStreakMotivation
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class GetPlanMotivationMessageUseCaseTest {
+    private val fixedNowMillis = 1_700_000_000_000L
+    private val fixedToday = LocalDate(2026, 5, 24)
+    private val timestampProvider = CurrentTimestampProvider { fixedNowMillis }
+    private val dateProvider = LocalDateTimeProvider { LocalDateTime(fixedToday, LocalTime(0, 0)) }
+
+    private fun useCase(
+        milestone: Milestone? = null,
+        streak: Streak? = null,
+        daySituation: DaySituation? = null,
+        progress: OverallProgress = OverallProgress.Zero,
+        onMilestoneInvoked: (days: List<DayModel>, nowMillis: Long) -> Unit = { _, _ -> },
+        onStreakInvoked: (days: List<DayModel>, today: LocalDate) -> Unit = { _, _ -> },
+        onDaySituationInvoked: (days: List<DayModel>, today: LocalDate) -> Unit = { _, _ -> },
+        onProgressInvoked: (progress: Float) -> Unit = {},
+    ) = GetPlanMotivationMessageUseCase(
+        currentTimestampProvider = timestampProvider,
+        localDateTimeProvider = dateProvider,
+        resolveMilestoneMotivation = { days, nowMillis ->
+            onMilestoneInvoked(days, nowMillis)
+            milestone
+        },
+        resolveStreakMotivation = { days, today ->
+            onStreakInvoked(days, today)
+            streak
+        },
+        resolveDaySituationMotivation = { days, today ->
+            onDaySituationInvoked(days, today)
+            daySituation
+        },
+        resolveOverallProgressMotivation = { value ->
+            onProgressInvoked(value)
+            progress
+        },
+    )
+
+    @Test
+    fun `returns milestone when milestone resolver returns non-null`() {
+        val result = useCase(
+            milestone = Milestone.EnteredNewTestament,
+            streak = Streak.Day7,
+            daySituation = DaySituation.Completed,
+            progress = OverallProgress.Halfway,
+        ).invoke(weeks = listOf(week(day(number = 1))), bibleProgress = 50f)
+
+        assertEquals(Milestone.EnteredNewTestament, result)
+    }
+
+    @Test
+    fun `falls back to streak when milestone is null`() {
+        val result = useCase(
+            milestone = null,
+            streak = Streak.Day7,
+            daySituation = DaySituation.Completed,
+            progress = OverallProgress.Halfway,
+        ).invoke(weeks = listOf(week(day(number = 1))), bibleProgress = 50f)
+
+        assertEquals(Streak.Day7, result)
+    }
+
+    @Test
+    fun `falls back to day situation when milestone and streak are null`() {
+        val result = useCase(
+            milestone = null,
+            streak = null,
+            daySituation = DaySituation.NotStarted,
+            progress = OverallProgress.Halfway,
+        ).invoke(weeks = listOf(week(day(number = 1))), bibleProgress = 50f)
+
+        assertEquals(DaySituation.NotStarted, result)
+    }
+
+    @Test
+    fun `falls back to overall progress when all higher-priority resolvers return null`() {
+        val result: PlanMotivationMessage = useCase(
+            milestone = null,
+            streak = null,
+            daySituation = null,
+            progress = OverallProgress.Halfway,
+        ).invoke(weeks = listOf(week(day(number = 1))), bibleProgress = 50f)
+
+        assertEquals(OverallProgress.Halfway, result)
+    }
+
+    @Test
+    fun `forwards flattened days and now to milestone resolver`() {
+        var capturedDays: List<DayModel>? = null
+        var capturedNow: Long? = null
+        val d1 = day(number = 1, passages = listOf(passage(BookId.GEN)))
+        val d2 = day(number = 2, passages = listOf(passage(BookId.EXO)))
+        val weeks = listOf(week(d1, d2))
+
+        useCase(
+            milestone = Milestone.FirstBookCompleted,
+            onMilestoneInvoked = { days, now ->
+                capturedDays = days
+                capturedNow = now
+            },
+        ).invoke(weeks = weeks, bibleProgress = 0f)
+
+        assertEquals(listOf(d1, d2), capturedDays)
+        assertEquals(fixedNowMillis, capturedNow)
+    }
+
+    @Test
+    fun `forwards today to streak and day situation resolvers`() {
+        var streakToday: LocalDate? = null
+        var daySituationToday: LocalDate? = null
+
+        useCase(
+            milestone = null,
+            streak = null,
+            daySituation = DaySituation.NotStarted,
+            onStreakInvoked = { _, today -> streakToday = today },
+            onDaySituationInvoked = { _, today -> daySituationToday = today },
+        ).invoke(weeks = listOf(week(day())), bibleProgress = 0f)
+
+        assertEquals(fixedToday, streakToday)
+        assertEquals(fixedToday, daySituationToday)
+    }
+
+    @Test
+    fun `forwards bible progress to progress resolver`() {
+        var capturedProgress: Float? = null
+
+        useCase(
+            milestone = null,
+            streak = null,
+            daySituation = null,
+            progress = OverallProgress.Halfway,
+            onProgressInvoked = { capturedProgress = it },
+        ).invoke(weeks = emptyList(), bibleProgress = 42.5f)
+
+        assertEquals(42.5f, capturedProgress)
+    }
+
+    private fun week(
+        vararg days: DayModel,
+        number: Int = 1,
+    ): WeekPlanModel = WeekPlanModel(number = number, days = days.toList())
+}

--- a/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/MotivationFixtures.kt
+++ b/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/MotivationFixtures.kt
@@ -1,0 +1,45 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.model.book.BookId
+import com.quare.bibleplanner.core.model.plan.ChapterModel
+import com.quare.bibleplanner.core.model.plan.DayModel
+import com.quare.bibleplanner.core.model.plan.PassageModel
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+
+internal fun passage(
+    bookId: BookId = BookId.GEN,
+    isRead: Boolean = false,
+): PassageModel = PassageModel(
+    bookId = bookId,
+    chapters = listOf(
+        ChapterModel(number = 1, startVerse = null, endVerse = null, bookId = bookId),
+    ),
+    isRead = isRead,
+    chapterRanges = null,
+)
+
+internal fun day(
+    number: Int = 1,
+    isRead: Boolean = false,
+    isToday: Boolean = false,
+    readVerses: Int = 0,
+    totalVerses: Int = 10,
+    plannedReadDate: LocalDate? = null,
+    readTimestamp: Long? = null,
+    passages: List<PassageModel> = listOf(passage(isRead = isRead)),
+): DayModel = DayModel(
+    number = number,
+    passages = passages,
+    isRead = isRead,
+    totalVerses = totalVerses,
+    readVerses = readVerses,
+    readTimestamp = readTimestamp,
+    plannedReadDate = plannedReadDate,
+    notes = null,
+    isToday = isToday,
+)
+
+internal fun LocalDate.toEpochMillisLocal(): Long =
+    atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds()

--- a/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveDaySituationMotivationUseCaseTest.kt
+++ b/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveDaySituationMotivationUseCaseTest.kt
@@ -1,0 +1,101 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.DaySituation
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ResolveDaySituationMotivationUseCaseTest {
+    private val useCase = ResolveDaySituationMotivationUseCase()
+    private val today = LocalDate(2026, 5, 24)
+
+    @Test
+    fun `today fully read returns Completed`() {
+        val days = listOf(
+            day(isToday = true, isRead = true, readVerses = 10, totalVerses = 10),
+        )
+        assertEquals(DaySituation.Completed, useCase(days, today))
+    }
+
+    @Test
+    fun `today partially read returns Started`() {
+        val days = listOf(
+            day(isToday = true, isRead = false, readVerses = 3, totalVerses = 10),
+        )
+        assertEquals(DaySituation.Started, useCase(days, today))
+    }
+
+    @Test
+    fun `today not started with no overdue returns NotStarted`() {
+        val days = listOf(
+            day(isToday = true, isRead = false, readVerses = 0, totalVerses = 10),
+        )
+        assertEquals(DaySituation.NotStarted, useCase(days, today))
+    }
+
+    @Test
+    fun `one overdue returns OneOverdue`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = false,
+                isToday = false,
+                totalVerses = 10,
+                plannedReadDate = today.minus(1, DateTimeUnit.DAY),
+            ),
+        )
+        assertEquals(DaySituation.OneOverdue, useCase(days, today))
+    }
+
+    @Test
+    fun `multiple overdue returns MultipleOverdue`() {
+        val days = listOf(
+            day(number = 1, isRead = false, plannedReadDate = today.minus(2, DateTimeUnit.DAY)),
+            day(number = 2, isRead = false, plannedReadDate = today.minus(1, DateTimeUnit.DAY)),
+        )
+        assertEquals(DaySituation.MultipleOverdue, useCase(days, today))
+    }
+
+    @Test
+    fun `today completed beats overdue`() {
+        val days = listOf(
+            day(number = 1, isRead = false, plannedReadDate = today.minus(1, DateTimeUnit.DAY)),
+            day(number = 2, isToday = true, isRead = true, readVerses = 10, totalVerses = 10),
+        )
+        assertEquals(DaySituation.Completed, useCase(days, today))
+    }
+
+    @Test
+    fun `today started beats overdue`() {
+        val days = listOf(
+            day(number = 1, isRead = false, plannedReadDate = today.minus(1, DateTimeUnit.DAY)),
+            day(number = 2, isToday = true, isRead = false, readVerses = 4, totalVerses = 10),
+        )
+        assertEquals(DaySituation.Started, useCase(days, today))
+    }
+
+    @Test
+    fun `overdue beats not-started`() {
+        val days = listOf(
+            day(number = 1, isRead = false, plannedReadDate = today.minus(1, DateTimeUnit.DAY)),
+            day(number = 2, isToday = true, isRead = false, readVerses = 0, totalVerses = 10),
+        )
+        assertEquals(DaySituation.OneOverdue, useCase(days, today))
+    }
+
+    @Test
+    fun `empty rest day today returns null`() {
+        val days = listOf(
+            day(isToday = true, isRead = false, readVerses = 0, totalVerses = 0),
+        )
+        assertNull(useCase(days, today))
+    }
+
+    @Test
+    fun `no today and no overdue returns null`() {
+        assertNull(useCase(emptyList(), today))
+    }
+}

--- a/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveMilestoneMotivationUseCaseTest.kt
+++ b/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveMilestoneMotivationUseCaseTest.kt
@@ -1,0 +1,267 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.model.book.BookId
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Milestone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ResolveMilestoneMotivationUseCaseTest {
+    private val useCase = ResolveMilestoneMotivationUseCase()
+    private val nowMillis = 1_700_000_000_000L
+    private val withinWindow = nowMillis - 60_000L
+    private val olderWithinWindow = nowMillis - 600_000L
+    private val outsideWindow = nowMillis - 25L * 60 * 60 * 1000L
+
+    @Test
+    fun `empty plan returns null`() {
+        assertNull(useCase(emptyList(), nowMillis))
+    }
+
+    @Test
+    fun `EnteredNewTestament triggers when crossing from OT to NT within 24h`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = olderWithinWindow,
+                passages = listOf(passage(BookId.GEN, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(passage(BookId.MAT, isRead = true)),
+            ),
+        )
+        assertEquals(Milestone.EnteredNewTestament, useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `EnteredNewTestament does not trigger without prior OT activity`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(passage(BookId.MAT, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = false,
+                passages = listOf(passage(BookId.MRK, isRead = false)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.LUK, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.FirstBookCompleted, useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `EnteredNewTestament does not trigger when earlier read already had NT`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = olderWithinWindow,
+                passages = listOf(passage(BookId.MAT, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(passage(BookId.MRK, isRead = true)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.GEN, isRead = false)),
+            ),
+            day(
+                number = 4,
+                isRead = false,
+                passages = listOf(passage(BookId.EXO, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.BookCompleted(BookId.MRK), useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `OnlyOneBookLeft triggers when exactly one unread book remains`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = outsideWindow,
+                passages = listOf(passage(BookId.GEN, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = false,
+                passages = listOf(passage(BookId.EXO, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.OnlyOneBookLeft(BookId.EXO), useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `OnlyOneBookLeft does not trigger in single-book plan`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = false,
+                passages = listOf(passage(BookId.GEN, isRead = false)),
+            ),
+        )
+        assertNull(useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `OnlyOneBookLeft does not trigger when multiple books still have unread passages`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = false,
+                passages = listOf(
+                    passage(BookId.GEN, isRead = false),
+                    passage(BookId.EXO, isRead = false),
+                ),
+            ),
+        )
+        assertNull(useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `FirstBookCompleted triggers when first book just closed within 24h`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(passage(BookId.GEN, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = false,
+                passages = listOf(passage(BookId.EXO, isRead = false)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.LEV, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.FirstBookCompleted, useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `BookCompleted triggers when a non-first book closes within 24h`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = olderWithinWindow,
+                passages = listOf(passage(BookId.GEN, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(passage(BookId.EXO, isRead = true)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.LEV, isRead = false)),
+            ),
+            day(
+                number = 4,
+                isRead = false,
+                passages = listOf(passage(BookId.NUM, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.BookCompleted(BookId.EXO), useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `BookCompleted does not trigger outside 24h window`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = outsideWindow - 1000L,
+                passages = listOf(passage(BookId.GEN, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = true,
+                readTimestamp = outsideWindow,
+                passages = listOf(passage(BookId.EXO, isRead = true)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.LEV, isRead = false)),
+            ),
+            day(
+                number = 4,
+                isRead = false,
+                passages = listOf(passage(BookId.NUM, isRead = false)),
+            ),
+        )
+        assertNull(useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `NT entry beats OnlyOneBookLeft when both apply`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = olderWithinWindow,
+                passages = listOf(passage(BookId.GEN, isRead = true)),
+            ),
+            day(
+                number = 2,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(passage(BookId.MAT, isRead = true)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.EXO, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.EnteredNewTestament, useCase(days, nowMillis))
+    }
+
+    @Test
+    fun `BookCompleted picks the canonical-last book when multiple close on the same day`() {
+        val days = listOf(
+            day(
+                number = 1,
+                isRead = true,
+                readTimestamp = withinWindow,
+                passages = listOf(
+                    passage(BookId.GEN, isRead = true),
+                    passage(BookId.EXO, isRead = true),
+                ),
+            ),
+            day(
+                number = 2,
+                isRead = false,
+                passages = listOf(passage(BookId.LEV, isRead = false)),
+            ),
+            day(
+                number = 3,
+                isRead = false,
+                passages = listOf(passage(BookId.NUM, isRead = false)),
+            ),
+        )
+        assertEquals(Milestone.BookCompleted(BookId.EXO), useCase(days, nowMillis))
+    }
+}

--- a/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveOverallProgressMotivationUseCaseTest.kt
+++ b/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveOverallProgressMotivationUseCaseTest.kt
@@ -1,0 +1,109 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.OverallProgress
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ResolveOverallProgressMotivationUseCaseTest {
+    private val useCase = ResolveOverallProgressMotivationUseCase()
+
+    @Test
+    fun `progress 0 returns Zero`() {
+        assertEquals(OverallProgress.Zero, useCase(0f))
+    }
+
+    @Test
+    fun `progress 1 returns EarlyStart`() {
+        assertEquals(OverallProgress.EarlyStart, useCase(1f))
+    }
+
+    @Test
+    fun `progress 5 returns EarlyStart`() {
+        assertEquals(OverallProgress.EarlyStart, useCase(5f))
+    }
+
+    @Test
+    fun `progress 6 returns BuildingSolid`() {
+        assertEquals(OverallProgress.BuildingSolid, useCase(6f))
+    }
+
+    @Test
+    fun `progress 15 returns BuildingSolid`() {
+        assertEquals(OverallProgress.BuildingSolid, useCase(15f))
+    }
+
+    @Test
+    fun `progress 16 returns ApproachingThird`() {
+        assertEquals(OverallProgress.ApproachingThird, useCase(16f))
+    }
+
+    @Test
+    fun `progress 30 returns ApproachingThird`() {
+        assertEquals(OverallProgress.ApproachingThird, useCase(30f))
+    }
+
+    @Test
+    fun `progress 31 returns PastThirty`() {
+        assertEquals(OverallProgress.PastThirty, useCase(31f))
+    }
+
+    @Test
+    fun `progress 49 returns PastThirty`() {
+        assertEquals(OverallProgress.PastThirty, useCase(49f))
+    }
+
+    @Test
+    fun `progress 50 returns Halfway`() {
+        assertEquals(OverallProgress.Halfway, useCase(50f))
+    }
+
+    @Test
+    fun `progress 51 returns MoreThanHalf`() {
+        assertEquals(OverallProgress.MoreThanHalf, useCase(51f))
+    }
+
+    @Test
+    fun `progress 74 returns MoreThanHalf`() {
+        assertEquals(OverallProgress.MoreThanHalf, useCase(74f))
+    }
+
+    @Test
+    fun `progress 75 returns ThreeQuarters`() {
+        assertEquals(OverallProgress.ThreeQuarters, useCase(75f))
+    }
+
+    @Test
+    fun `progress 76 returns FinalStretch`() {
+        assertEquals(OverallProgress.FinalStretch, useCase(76f))
+    }
+
+    @Test
+    fun `progress 90 returns FinalStretch`() {
+        assertEquals(OverallProgress.FinalStretch, useCase(90f))
+    }
+
+    @Test
+    fun `progress 91 returns AlmostThere`() {
+        assertEquals(OverallProgress.AlmostThere, useCase(91f))
+    }
+
+    @Test
+    fun `progress 99 returns AlmostThere`() {
+        assertEquals(OverallProgress.AlmostThere, useCase(99f))
+    }
+
+    @Test
+    fun `progress 100 returns Completed`() {
+        assertEquals(OverallProgress.Completed, useCase(100f))
+    }
+
+    @Test
+    fun `negative progress clamps to Zero`() {
+        assertEquals(OverallProgress.Zero, useCase(-5f))
+    }
+
+    @Test
+    fun `over 100 progress clamps to Completed`() {
+        assertEquals(OverallProgress.Completed, useCase(150f))
+    }
+}

--- a/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveStreakMotivationUseCaseTest.kt
+++ b/feature/reading_plan/src/commonTest/kotlin/com/quare/bibleplanner/feature/readingplan/domain/usecase/impl/ResolveStreakMotivationUseCaseTest.kt
@@ -1,0 +1,116 @@
+package com.quare.bibleplanner.feature.readingplan.domain.usecase.impl
+
+import com.quare.bibleplanner.core.date.LocalDateTimeProvider
+import com.quare.bibleplanner.feature.readingplan.domain.model.PlanMotivationMessage.Streak
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.toLocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+internal class ResolveStreakMotivationUseCaseTest {
+    private val systemTimeZone = TimeZone.currentSystemDefault()
+    private val provider = LocalDateTimeProvider { timestamp ->
+        Instant.fromEpochMilliseconds(timestamp).toLocalDateTime(systemTimeZone)
+    }
+    private val useCase = ResolveStreakMotivationUseCase(provider)
+    private val today = LocalDate(2026, 5, 24)
+
+    @Test
+    fun `single read today returns Day1`() {
+        val days = listOf(day(readTimestamp = today.toEpochMillisLocal()))
+        assertEquals(Streak.Day1, useCase(days, today))
+    }
+
+    @Test
+    fun `3 consecutive days returns Day3`() {
+        val days = (0..2).map { offset ->
+            day(
+                number = offset + 1,
+                readTimestamp = today.minus(offset, DateTimeUnit.DAY).toEpochMillisLocal(),
+            )
+        }
+        assertEquals(Streak.Day3, useCase(days, today))
+    }
+
+    @Test
+    fun `5 consecutive days returns Day3`() {
+        val days = (0..4).map { offset ->
+            day(
+                number = offset + 1,
+                readTimestamp = today.minus(offset, DateTimeUnit.DAY).toEpochMillisLocal(),
+            )
+        }
+        assertEquals(Streak.Day3, useCase(days, today))
+    }
+
+    @Test
+    fun `7 consecutive days returns Day7`() {
+        val days = (0..6).map { offset ->
+            day(
+                number = offset + 1,
+                readTimestamp = today.minus(offset, DateTimeUnit.DAY).toEpochMillisLocal(),
+            )
+        }
+        assertEquals(Streak.Day7, useCase(days, today))
+    }
+
+    @Test
+    fun `14 consecutive days returns Day14`() {
+        val days = (0..13).map { offset ->
+            day(
+                number = offset + 1,
+                readTimestamp = today.minus(offset, DateTimeUnit.DAY).toEpochMillisLocal(),
+            )
+        }
+        assertEquals(Streak.Day14, useCase(days, today))
+    }
+
+    @Test
+    fun `30 consecutive days returns Day30`() {
+        val days = (0..29).map { offset ->
+            day(
+                number = offset + 1,
+                readTimestamp = today.minus(offset, DateTimeUnit.DAY).toEpochMillisLocal(),
+            )
+        }
+        assertEquals(Streak.Day30, useCase(days, today))
+    }
+
+    @Test
+    fun `100 consecutive days returns Day100`() {
+        val days = (0..99).map { offset ->
+            day(
+                number = offset + 1,
+                readTimestamp = today.minus(offset, DateTimeUnit.DAY).toEpochMillisLocal(),
+            )
+        }
+        assertEquals(Streak.Day100, useCase(days, today))
+    }
+
+    @Test
+    fun `last read yesterday returns null`() {
+        val days = listOf(
+            day(readTimestamp = today.minus(1, DateTimeUnit.DAY).toEpochMillisLocal()),
+        )
+        assertNull(useCase(days, today))
+    }
+
+    @Test
+    fun `gap breaks streak`() {
+        val days = listOf(
+            day(number = 1, readTimestamp = today.toEpochMillisLocal()),
+            day(number = 2, readTimestamp = today.minus(2, DateTimeUnit.DAY).toEpochMillisLocal()),
+        )
+        assertEquals(Streak.Day1, useCase(days, today))
+    }
+
+    @Test
+    fun `empty days returns null`() {
+        assertNull(useCase(emptyList(), today))
+    }
+}

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/en.json
@@ -3,7 +3,8 @@
     "The reading plan screen now uses a two-column layout on tablets and larger displays, with the progress panel on the left and the weeks list on the right, both scrollable independently across the full screen.",
     "Today's reading is now highlighted in the day list, making it easier to find where you should be.",
     "Smoother response when marking days as read in the reading plan, especially on older devices.",
-    "Improved vertical alignment between the progress panel and the weeks list in the new two-column reading plan layout."
+    "Improved vertical alignment between the progress panel and the weeks list in the new two-column reading plan layout.",
+    "The message in the plan progress card now adapts to your journey, highlighting book milestones, your reading streak, today's reading, or your overall Bible progress."
   ],
   "1.14.0": [
     "When changing the app language, the current language now appears highlighted at the top of the list, with the rest sorted alphabetically."

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/es.json
@@ -3,7 +3,8 @@
     "La pantalla del plan de lectura ahora usa un diseño de dos columnas en tabletas y pantallas más grandes, con el panel de progreso a la izquierda y la lista de semanas a la derecha, ambos con desplazamiento independiente en todo el ancho de la pantalla.",
     "La lectura de hoy ahora aparece destacada en la lista de días, facilitando encontrar dónde debes estar.",
     "Respuesta más fluida al marcar días como leídos en el plan de lectura, especialmente en dispositivos más antiguos.",
-    "Mejor alineación vertical entre el panel de progreso y la lista de semanas en el nuevo diseño de dos columnas del plan de lectura."
+    "Mejor alineación vertical entre el panel de progreso y la lista de semanas en el nuevo diseño de dos columnas del plan de lectura.",
+    "El mensaje del panel de progreso del plan ahora se adapta a tu ritmo, destacando hitos de libros, tu racha de días leídos, tu lectura de hoy o tu progreso general en la Biblia."
   ],
   "1.14.0": [
     "Al cambiar el idioma de la aplicación, el idioma actual ahora aparece destacado en la parte superior de la lista, con los demás en orden alfabético."

--- a/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
+++ b/feature/release_notes/src/commonMain/composeResources/files/release_notes/pt.json
@@ -3,7 +3,8 @@
     "A tela do plano de leitura agora usa um layout em duas colunas em tablets e telas maiores, com o painel de progresso à esquerda e a lista de semanas à direita, ambos com rolagem independente em toda a largura da tela.",
     "A leitura de hoje agora aparece destacada na lista de dias, facilitando encontrar onde você deve estar.",
     "Resposta mais fluida ao marcar dias como lidos no plano de leitura, principalmente em aparelhos mais antigos.",
-    "Melhor alinhamento vertical entre o painel de progresso e a lista de semanas no novo layout de duas colunas do plano de leitura."
+    "Melhor alinhamento vertical entre o painel de progresso e a lista de semanas no novo layout de duas colunas do plano de leitura.",
+    "A mensagem do card de progresso do plano agora muda conforme seu ritmo, destacando marcos de livro, sequências de dias lidos, sua leitura de hoje ou seu progresso geral na Bíblia."
   ],
   "1.14.0": [
     "Ao trocar o idioma do aplicativo, o idioma atual aparece em destaque no topo da lista, com os demais em ordem alfabética."


### PR DESCRIPTION
The Plan progress card used to display a single hard-coded motivational message regardless of the user's state. With this change the message becomes adaptive, following the four-tier priority defined in the design system (Marco de livro → Streak → Situação do dia → Progresso geral).

What the user now sees:
- **Book milestones** (highest priority, last 24h): entering the New Testament, completing the very first book in the plan, completing any book, or being one book away from finishing the plan.
- **Reading streak** (calendar days with at least one reading, ending today, no gaps): tiered messages at 1, 3, 7, 14, 30 and 100 days.
- **Today's situation**: not started, started, completed, or 1+ overdue days.
- **Overall Bible progress range**: from 0% to 100% in 11 buckets.

Each variant has its own localized string in en, pt-BR and es.

Implementation:
- New \`PlanMotivationMessage\` sealed type in the reading plan domain layer.
- One \`fun interface\` per priority tier (\`ResolveMilestoneMotivation\`, \`ResolveStreakMotivation\`, \`ResolveDaySituationMotivation\`, \`ResolveOverallProgressMotivation\`) plus the orchestrator \`GetPlanMotivationMessage\`.
- \`PlanProgress\` now receives a \`PlanMotivationMessage?\` and resolves it to text via a composable mapper that reuses \`BookId.toBookNameResource()\`.
- \`LocalDateTimeProvider\` and \`CurrentTimestampProvider\` were converted to \`fun interface\` + Impl to enable mocking in tests; DI bindings updated accordingly.

Tests:
- 59 JVM tests in \`:feature:reading_plan\` covering each resolver's branches, priority order, internal milestone order, the 24h window, and orchestrator forwarding (resolvers mocked via lambdas).
- 10 JVM tests in \`:core:model\` for \`BookId.isNewTestament()\` / \`isOldTestament()\` (covers all 66 books plus boundaries).

## Test plan
- [ ] Open the reading plan on a device — verify the motivational message appears and matches one of the four tiers.
- [ ] Mark today's day as read after a streak of consecutive days — verify the appropriate streak message shows.
- [ ] Mark every day of a book — verify the "book completed" message appears for ~24h.
- [ ] Switch app language to pt-BR and es — verify the messages are localized.
- [ ] Reset progress — verify the 0% message displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)