### PR TITLE
enhancement: harden CI security and automate Apple secret rotation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ on:
         type: boolean
         default: true
 
+# Least privilege by default — only the finalize job needs write access.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release
@@ -125,7 +125,8 @@ jobs:
         with:
           name: android-aab
           path: androidApp/build/outputs/bundle/release/
-          retention-days: 5
+          # Signed binaries are downloadable by anyone on a public repo — keep them short-lived.
+          retention-days: 1
           if-no-files-found: error
 
   android-upload:
@@ -232,7 +233,8 @@ jobs:
         with:
           name: ios-ipa
           path: build/ios/
-          retention-days: 5
+          # Signed binaries are downloadable by anyone on a public repo — keep them short-lived.
+          retention-days: 1
           if-no-files-found: error
 
   ios-upload:
@@ -278,6 +280,9 @@ jobs:
     needs: [plan, android-upload, ios-upload]
     if: ${{ inputs.platforms == 'both' && inputs.track == 'production' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/rotate-apple-secret.yml
+++ b/.github/workflows/rotate-apple-secret.yml
@@ -1,0 +1,65 @@
+name: rotate-apple-secret
+
+# Rotates the Sign in with Apple client secret on the Supabase project.
+#
+# Apple caps the secret's validity at 6 months, so it must be regenerated
+# periodically or Apple sign-in silently breaks on Android/desktop (the iOS
+# native flow does not use it). The schedule runs in January, June and
+# November — always renewing before the previous secret expires.
+#
+# The job runs in the `Production` environment, so each run (scheduled or
+# manual) waits for a required-reviewer approval before it can read secrets.
+# Approve it from the Actions tab when notified.
+#
+# Required secrets (Production environment):
+#   APPLE_SIGNIN_KEY_P8   — contents of the AuthKey_S6T3824BDQ.p8 private key
+#   SUPABASE_ACCESS_TOKEN — Supabase personal access token
+#                           (supabase.com/dashboard/account/tokens)
+#
+# See docs/setup_apple_signin.md for the manual rotation fallback.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 1 */5 *' # 12:00 UTC on the 1st of January, June and November
+
+permissions:
+  contents: read
+
+jobs:
+  rotate:
+    name: Generate and push a fresh client secret
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Generate the client secret JWT
+        env:
+          APPLE_SIGNIN_KEY_P8: ${{ secrets.APPLE_SIGNIN_KEY_P8 }}
+        run: |
+          umask 077
+          printf '%s\n' "$APPLE_SIGNIN_KEY_P8" > "$RUNNER_TEMP/apple_signin_key.p8"
+          APPLE_AUTH_KEY_P8="$RUNNER_TEMP/apple_signin_key.p8" \
+            python3 supabase/generate_apple_client_secret.py "$RUNNER_TEMP/apple_client_secret"
+          rm "$RUNNER_TEMP/apple_signin_key.p8"
+
+      - name: Push the new secret to the Supabase auth config
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X PATCH "https://api.supabase.com/v1/projects/yncazduslqvphguhwdel/config/auth" \
+            -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "{\"external_apple_secret\": \"$(cat "$RUNNER_TEMP/apple_client_secret")\"}")
+          rm "$RUNNER_TEMP/apple_client_secret"
+          if [ "$status" != "200" ]; then
+            echo "❌ Supabase Management API returned HTTP $status"
+            exit 1
+          fi
+          echo "✅ Apple client secret rotated (HTTP $status)."

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,6 +20,9 @@ on:
       - '.editorconfig'
       - 'build.gradle.kts'
 
+permissions:
+  contents: read
+
 # Cancels in-progress runs if a new commit is pushed to the same PR or branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/docs/setup_apple_signin.md
+++ b/docs/setup_apple_signin.md
@@ -36,7 +36,17 @@ be regenerated and pushed to Supabase again.
 3. Writes the JWT to the output file path passed as argument — the private key and the secret are never
    printed to stdout.
 
-### Regenerating the secret
+### Automatic rotation (preferred)
+
+The [`rotate-apple-secret`](../.github/workflows/rotate-apple-secret.yml) workflow regenerates and
+pushes a fresh secret on the 1st of January, June and November (and on demand via *Run workflow*).
+Each run waits for approval on the `Production` environment — approve it from the Actions tab when
+notified. It depends on two secrets in that environment:
+
+- `APPLE_SIGNIN_KEY_P8` — contents of the `.p8` private key
+- `SUPABASE_ACCESS_TOKEN` — Supabase personal access token
+
+### Manual rotation (fallback)
 
 ```bash
 APPLE_AUTH_KEY_P8=/path/to/AuthKey_S6T3824BDQ.p8 \
@@ -50,9 +60,8 @@ The push reads `supabase/config.toml` (which references the secret via
 `env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)`), shows a diff, and asks for confirmation.
 `supabase/.apple_client_secret` is gitignored — never commit it.
 
-**When to run:** before the current secret expires (the script prints the new expiry date when it runs;
-set a reminder ~6 months after each rotation), or immediately if the key is ever revoked/rotated in the
-Apple Developer portal (update `KEY_ID`/`TEAM_ID`/`CLIENT_ID` constants in the script if those change).
+If the key is ever revoked/rotated in the Apple Developer portal, update the
+`KEY_ID`/`TEAM_ID`/`CLIENT_ID` constants in the script and the `APPLE_SIGNIN_KEY_P8` secret.
 
 ## Supabase configuration
 


### PR DESCRIPTION
## What

Security hardening of the CI/CD pipeline (this is a public repo whose release workflow holds the Android keystore, App Store Connect API key and match SSH key), plus a scheduled workflow that rotates the Sign in with Apple client secret before its 6-month expiry.

## Changes

- **Least-privilege `GITHUB_TOKEN`**: workflows default to `contents: read`; only the `finalize` job keeps `contents: write, pull-requests: write`.
- **`retention-days: 5` → `1`** for the signed AAB/IPA artifacts — on a public repo anyone can download workflow artifacts.
- **New `rotate-apple-secret` workflow**: runs on the 1st of Jan/Jun/Nov (and on demand), gated by the `Production` environment's required reviewer. It generates the ES256 JWT with the existing `supabase/generate_apple_client_secret.py` and PATCHes it to the Supabase Management API with plain `curl`. Requires two new environment secrets: `APPLE_SIGNIN_KEY_P8` and `SUPABASE_ACCESS_TOKEN`.
- `docs/setup_apple_signin.md` updated: automatic rotation documented as the preferred path, manual flow kept as fallback.

## Repo settings applied alongside (not in this diff)

- Secret scanning + push protection + Dependabot alerts/security updates enabled.
- `Production` environment restricted to deployments from `main`.
- "Main rules" ruleset now also blocks force pushes (`non_fast_forward`).

## Pending manual step

Add the two secrets to the `Production` environment before the first rotation run: `APPLE_SIGNIN_KEY_P8` (contents of the `.p8`) and `SUPABASE_ACCESS_TOKEN` (created at supabase.com/dashboard/account/tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)