### PR TITLE
enhancement: run Apple secret rotation unattended in its own environment

### DIFF
--- a/.github/workflows/rotate-apple-secret.yml
+++ b/.github/workflows/rotate-apple-secret.yml
@@ -7,11 +7,12 @@ name: rotate-apple-secret
 # native flow does not use it). The schedule runs in January, June and
 # November — always renewing before the previous secret expires.
 #
-# The job runs in the `Production` environment, so each run (scheduled or
-# manual) waits for a required-reviewer approval before it can read secrets.
-# Approve it from the Actions tab when notified.
+# The job runs unattended in the `apple-secret-rotation` environment (no
+# required reviewer, deployments restricted to main). This is safe only while
+# write access to the repository is limited to its owner — anyone with write
+# can reach this environment's secrets through a workflow on main.
 #
-# Required secrets (Production environment):
+# Required secrets (apple-secret-rotation environment):
 #   APPLE_SIGNIN_KEY_P8   — contents of the AuthKey_S6T3824BDQ.p8 private key
 #   SUPABASE_ACCESS_TOKEN — Supabase personal access token
 #                           (supabase.com/dashboard/account/tokens)
@@ -30,7 +31,7 @@ jobs:
   rotate:
     name: Generate and push a fresh client secret
     runs-on: ubuntu-latest
-    environment: Production
+    environment: apple-secret-rotation
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/docs/setup_apple_signin.md
+++ b/docs/setup_apple_signin.md
@@ -40,11 +40,14 @@ be regenerated and pushed to Supabase again.
 
 The [`rotate-apple-secret`](../.github/workflows/rotate-apple-secret.yml) workflow regenerates and
 pushes a fresh secret on the 1st of January, June and November (and on demand via *Run workflow*).
-Each run waits for approval on the `Production` environment — approve it from the Actions tab when
-notified. It depends on two secrets in that environment:
+It runs unattended in the `apple-secret-rotation` environment (no approval; deployments restricted
+to `main`) and depends on two secrets in that environment:
 
 - `APPLE_SIGNIN_KEY_P8` — contents of the `.p8` private key
 - `SUPABASE_ACCESS_TOKEN` — Supabase personal access token
+
+> Because the environment has no required reviewer, keep repository write access restricted —
+> anyone with write can reach these secrets through a workflow on `main`.
 
 ### Manual rotation (fallback)
 


### PR DESCRIPTION
Moves the `rotate-apple-secret` workflow from the `Production` environment to the new `apple-secret-rotation` environment, which has **no required reviewer** (deployments restricted to `main`), so scheduled rotations run unattended instead of waiting for a manual approval.

Security context: this is acceptable because repository write access is being restricted to the owner — anyone with write access can reach an unreviewed environment's secrets through a workflow on `main`. The `Production` environment (release pipeline) keeps its required-reviewer gate, which also serves as the version-review checkpoint.

Pending manual steps (owner):
- Move/add the two secrets (`APPLE_SIGNIN_KEY_P8`, `SUPABASE_ACCESS_TOKEN`) to the `apple-secret-rotation` environment.
- Restrict collaborator write access in Settings → Collaborators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)